### PR TITLE
[CRM457-549] Add events to main claim object and allow update via post/put

### DIFF
--- a/alembic/versions/4728f5eac46d_add_events_to_claim.py
+++ b/alembic/versions/4728f5eac46d_add_events_to_claim.py
@@ -1,0 +1,27 @@
+"""add-events-to-claim
+
+Revision ID: 4728f5eac46d
+Revises: c889c45342e7
+Create Date: 2023-10-05 13:37:51.093405
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSON
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4728f5eac46d"
+down_revision: Union[str, None] = "c889c45342e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("application", sa.Column("events", JSON()))
+
+
+def downgrade() -> None:
+    op.drop_column("application", "events")

--- a/laa_crime_application_store_app/models/application.py
+++ b/laa_crime_application_store_app/models/application.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -10,3 +11,4 @@ class Application(BaseModel):
     application_state: str
     application_risk: str
     application: dict
+    events: List[dict]

--- a/laa_crime_application_store_app/models/application_new.py
+++ b/laa_crime_application_store_app/models/application_new.py
@@ -1,6 +1,7 @@
+from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ApplicationNew(BaseModel):
@@ -9,3 +10,4 @@ class ApplicationNew(BaseModel):
     application_state: str | None
     application_risk: str | None
     application: dict | None
+    events: Optional[List[dict]] = Field([])

--- a/laa_crime_application_store_app/models/application_update.py
+++ b/laa_crime_application_store_app/models/application_update.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -11,3 +11,4 @@ class ApplicationUpdate(BaseModel):
     application_risk: str | None
     updated_application_risk: Optional[str] = Field(None)
     application: dict | None
+    events: Optional[List[dict]] = Field([])

--- a/laa_crime_application_store_app/routers/v1/application.py
+++ b/laa_crime_application_store_app/routers/v1/application.py
@@ -58,6 +58,7 @@ async def get_application(app_id: UUID | None = None, db: Session = Depends(get_
         json_schema_version=application_version.json_schema_version,
         application_state=application.application_state,
         application_risk=application.application_risk,
+        events=application.events or [],
         application=application_version.application,
     )
 
@@ -69,6 +70,7 @@ async def post_application(request: ApplicationNew, db: Session = Depends(get_db
         current_version=1,
         application_state=request.application_state,
         application_risk=request.application_risk,
+        events=request.events,
     )
     new_application_version = ApplicationVersion(
         application_id=request.application_id,
@@ -107,7 +109,6 @@ async def put_application(
                 application_state=request.application_state,
                 application_risk=request.application_risk,
             )
-            db.add(application)
 
         application_version = (
             db.query(ApplicationVersion)
@@ -131,6 +132,9 @@ async def put_application(
 
         application.current_version += 1
         application.application_state = request.application_state
+        application.events = request.events
+        db.add(application)
+
         if request.updated_application_risk is not None:
             application.application_risk = request.updated_application_risk
         new_application_version = ApplicationVersion(

--- a/laa_crime_application_store_app/schema/application_schema.py
+++ b/laa_crime_application_store_app/schema/application_schema.py
@@ -1,4 +1,4 @@
-from sqlalchemy import UUID, Column, Integer, Text
+from sqlalchemy import JSON, UUID, Column, Integer, Text
 from sqlalchemy.orm import relationship
 
 from laa_crime_application_store_app.data.database import Base
@@ -12,3 +12,4 @@ class Application(Base):
     application_state = Column(Text, nullable=False)
     application_risk = Column(Text, nullable=False)
     versions = relationship("ApplicationVersion", back_populates="application_record")
+    events = Column(JSON)


### PR DESCRIPTION
## Description of change
Add events storage and retrieval to application object

## Link to relevant ticket
[CRM457-549](https://dsdmoj.atlassian.net/browse/CRM457-549)


[CRM457-549]: https://dsdmoj.atlassian.net/browse/CRM457-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ