### PR TITLE
Separate test workflows out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,8 @@ jobs:
 
 workflows:
   version: 2
-  pr-checks:
+
+  test:
     jobs:
       - lint-app:
           filters:
@@ -244,11 +245,18 @@ workflows:
             branches:
               ignore:
                 - main
+
+  build-push-branch:
+    jobs:
+      - branch-build-approval:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - main
       - build-and-push:
-            requires:
-              - lint-app
-              - test-app
-              - scan-docker-image
+          requires:
+              - branch-build-approval
       - hold-dev:
           type: approval
           requires:
@@ -276,7 +284,7 @@ workflows:
           requires:
             - deploy-uat
 
-  main-deploy:
+  test-build-deploy-main:
     jobs:
       - lint-app:
           filters:
@@ -296,6 +304,7 @@ workflows:
       - build-and-push:
           requires:
             - lint-app
+            - test-app
             - scan-docker-image
       - hold-dev:
           type: approval


### PR DESCRIPTION
## Description of change
Modify pipeline to separate test workflows out

So we can build and deploy changes to this
datastore in a similar manner to its "frontends"
- laa-claim-non-standard-magistrate-fee-backend
- laa-assess-non-standard-magistrate-fee

### example branch (non-main) workflow:
test:
<img width="923" alt="Screenshot 2023-12-19 at 17 06 05" src="https://github.com/ministryofjustice/laa-crime-application-store/assets/7016425/7169cb3d-1207-4522-9bd0-6cbafa714953">

build and deploy:
<img width="2042" alt="Screenshot 2023-12-19 at 17 05 20" src="https://github.com/ministryofjustice/laa-crime-application-store/assets/7016425/c12ed5d9-7b94-4f12-be36-e6d9dff37de1">


### example main branch workflow:
test build and deploy
<img width="2181" alt="Screenshot 2023-12-19 at 17 03 30" src="https://github.com/ministryofjustice/laa-crime-application-store/assets/7016425/71426ec3-4616-4432-8f5e-15e773d48f55">