### PR TITLE
force apk installation for expat version 2.6.0-r0 or higher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update-cache upgrade \
 && apk --no-cache add --upgrade gcc \
     musl-dev \
     build-base \
-    "expat>2.6.0-r0"
+    expat>2.6.0-r0
 
 COPY ./Pipfile /code/Pipfile
 COPY ./Pipfile.lock /code/Pipfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update-cache upgrade \
 && apk --no-cache add --upgrade gcc \
     musl-dev \
     build-base \
-    expat
+    "expat>2.6.0-r0"
 
 COPY ./Pipfile /code/Pipfile
 COPY ./Pipfile.lock /code/Pipfile.lock


### PR DESCRIPTION
[To fix Snyk issue]( https://security.snyk.io/vuln/SNYK-ALPINE318-EXPAT-6241039)
