### PR TITLE
Use correct namespace for ingress

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -35,7 +35,7 @@ service:
 
 ingress:
   enabled: true
-  namespace: laa-crime-application-store-prod
+  namespace: laa-crime-application-store-production
   className: modsec
   annotations:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"


### PR DESCRIPTION
## Description of change
Use “laa-crime-application-store-production”  instead of “laa-crime-application-store-prod” for production ingress namespace
