### PR TITLE
CRM457-919-Update docker file to fix M1 issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /code
 RUN apk --update-cache upgrade \
 && apk --no-cache add --upgrade gcc \
     musl-dev \
+    libffi-dev \
     build-base \
     expat>2.6.0-r0
 


### PR DESCRIPTION
## Description of change

This is an update to the Docker image to try and fix the error when it doesn't build on an M1 machine. See comment on this stackoverflow.

https://stackoverflow.com/a/71372163

## Link to relevant ticket

[CRM457-919](https://dsdmoj.atlassian.net/browse/CRM457-919)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

[CRM457-919]: https://dsdmoj.atlassian.net/browse/CRM457-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ