### PR TITLE
Automate Deployment to Main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
 workflows:
   version: 2
 
-  test:
+  test-opened-pr:
     jobs:
       - lint-app:
           filters:
@@ -236,7 +236,7 @@ workflows:
               ignore:
                 - main
 
-  build-and-deploy:
+  build-and-deploy-open-pr:
     jobs:
       - build-and-push: {}
       - deploy-dev:
@@ -248,33 +248,8 @@ workflows:
           context: laa-crime-application-store-dev
           requires:
             - deploy-dev
-      - hold-uat:
-          type: approval
-          requires:
-            - build-and-push
-          filters:
-            branches:
-              only:
-                - mainx
-      - deploy-uat:
-          context: laa-crime-application-store-uat
-          requires:
-            - hold-uat
-          filters:
-            branches:
-              only:
-                - main
-      - postman-test:
-          name: uat postman tests
-          context: laa-crime-application-store-uat
-          requires:
-            - deploy-uat
-          filters:
-            branches:
-              only:
-                - main
 
-  test-build-deploy-main:
+  test-build-deploy-merged-pr:
     jobs:
       - lint-app:
           filters:
@@ -296,37 +271,32 @@ workflows:
             - lint-app
             - test-app
             - scan-docker-image
-      - hold-dev:
-          type: approval
-          requires:
-            - build-and-push
       - deploy-dev:
           context: laa-crime-application-store-dev
           requires:
-            - hold-dev
+              - build-and-push
       - postman-test:
           name: dev postman tests
           context: laa-crime-application-store-dev
           requires:
             - deploy-dev
-      - hold-uat:
-          type: approval
-          requires:
-            - build-and-push
       - deploy-uat:
           context: laa-crime-application-store-uat
-          requires:
-            - hold-uat
+          filters:
+              branches:
+                  only:
+                      - main
       - postman-test:
           name: uat postman tests
           context: laa-crime-application-store-uat
           requires:
             - deploy-uat
-      - hold-prod:
-          type: approval
-          requires:
-            - build-and-push
       - deploy-prod:
           context: laa-crime-application-store-prod
+          filters:
+              branches:
+                  only:
+                      - main
           requires:
-            - hold-prod
+           - deploy-uat
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,8 @@ workflows:
             - deploy-dev
       - deploy-uat:
           context: laa-crime-application-store-uat
+          requires:
+              - build-and-push
           filters:
               branches:
                   only:


### PR DESCRIPTION
## Description of change

Automate deployment to prod for main

Until we go to private beta, and perhaps even after that,
we might as well deploy to UAT and then production automatically.

This will:

expose any deployment issues immediately on a per merge basis
not incur overhead of devs remembering to deploy

## Link to relevant ticket

[CRM457-](https://dsdmoj.atlassian.net/browse/CRM457-)

## Notes for reviewer

Have taken opportunity to remove some unreached steps and rename jobs

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature