### PR TITLE
CRM457-1327: More fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,12 +375,16 @@ workflows:
   build-and-deploy-open-pr:
     jobs:
       - build-and-push:
-        filters:
+          filters:
             branches:
               ignore:
                 - main
       - deploy-dev:
           context: laa-crime-application-store-dev
+          filters:
+            branches:
+              ignore:
+                - main
           requires:
             - build-and-push
 

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -9,7 +9,7 @@ private
 
   def build_args
     {
-      branch_name: ENV.fetch("APP_BRANCH_NAME", nil),
+      app_branch: ENV.fetch("APP_BRANCH_NAME", nil),
       build_date: ENV.fetch("APP_BUILD_DATE", nil),
       build_tag: ENV.fetch("APP_BUILD_TAG", nil),
       commit_id: ENV.fetch("APP_GIT_COMMIT", nil),

--- a/app/jobs/notify_subscriber.rb
+++ b/app/jobs/notify_subscriber.rb
@@ -5,15 +5,7 @@ class NotifySubscriber < ApplicationJob
   def perform(subscriber_id, submission_id)
     subscriber = Subscriber.find(subscriber_id)
 
-    response = HTTParty.post(
-      subscriber.webhook_url,
-      headers:,
-      body: {
-        submission_id:,
-      }.to_json,
-    )
-
-    return if response.code == 200
+    return if send_message_to_webhook(subscriber.webhook_url, submission_id)
 
     subscriber.with_lock do
       subscriber.failed_attempts += 1
@@ -22,7 +14,22 @@ class NotifySubscriber < ApplicationJob
 
     return if delete_subscriber(subscriber)
 
-    raise ClientResponseError, "Failed to notify subscriber about #{submission_id} - #{subscriber.webhook_url} returned #{response.code}"
+    raise ClientResponseError, "Failed to notify subscriber about #{submission_id} - #{subscriber.webhook_url} returned error"
+  end
+
+  def send_message_to_webhook(webhook_url, submission_id)
+    response = HTTParty.post(
+      webhook_url,
+      headers:,
+      body: {
+        submission_id:,
+      }.to_json,
+    )
+
+    response.code == 200
+  rescue Socket::ResolutionError
+    # If the subscriber web app has been taken fully offline and its DNS removed, this will fire
+    false
   end
 
   def delete_subscriber(subscriber)

--- a/app/services/tokens/verification_service.rb
+++ b/app/services/tokens/verification_service.rb
@@ -2,7 +2,9 @@ module Tokens
   class VerificationService
     class << self
       def call(headers)
-        return { valid: true, role: :unknown } if ENV.fetch("AUTHENTICATION_REQUIRED", "true") == "false"
+        if ENV.fetch("AUTHENTICATION_REQUIRED", "true") == "false"
+          return { valid: true, role: headers.fetch("X-Client-Type", "unknown").to_sym }
+        end
 
         jwt = headers["Authorization"].gsub(/^Bearer /, "")
         data = parse(jwt)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# If this is set to a positive number, Puma will launch in cluster mode.
+# Note that on Mac you may need to also have env var `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
+workers ENV.fetch("WORKERS", 0)
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -55,10 +55,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 128Mi
+    memory: 500Mi
   requests:
     cpu: 10m
-    memory: 128Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -55,10 +55,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 128Mi
+    memory: 500Mi
   requests:
     cpu: 10m
-    memory: 128Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false

--- a/spec/requests/create_submission_spec.rb
+++ b/spec/requests/create_submission_spec.rb
@@ -1,73 +1,109 @@
 require "rails_helper"
 
 RSpec.describe "Create submission" do
-  before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :provider) }
+  context "when authenticated with bearer token" do
+    before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :provider) }
 
-  let(:created_record) { Submission.last }
+    let(:created_record) { Submission.last }
 
-  it "saves what I send" do
-    id = SecureRandom.uuid
-    post "/v1/submissions", params: {
-      application_id: id,
-      application_type: "crm4",
-      application_risk: "low",
-      json_schema_version: 1,
-      application: { foo: :bar },
-    }
-    expect(response).to have_http_status :created
+    it "saves what I send" do
+      id = SecureRandom.uuid
+      post "/v1/submissions", params: {
+        application_id: id,
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
+      expect(response).to have_http_status :created
 
-    expect(created_record).to have_attributes(
-      id:,
-      application_state: "submitted",
-      application_type: "crm4",
-      application_risk: "low",
-      current_version: 1,
-    )
+      expect(created_record).to have_attributes(
+        id:,
+        application_state: "submitted",
+        application_type: "crm4",
+        application_risk: "low",
+        current_version: 1,
+      )
 
-    expect(created_record.latest_version).to have_attributes(
-      json_schema_version: 1,
-      application: { "foo" => "bar" },
-    )
+      expect(created_record.latest_version).to have_attributes(
+        json_schema_version: 1,
+        application: { "foo" => "bar" },
+      )
+    end
+
+    it "validates what I send" do
+      post "/v1/submissions", params: {
+        application_id: SecureRandom.uuid,
+      }
+      expect(response).to have_http_status :unprocessable_entity
+    end
+
+    it "detects conflicting information" do
+      submission = create(:submission)
+      post "/v1/submissions", params: {
+        application_id: submission.id,
+      }
+      expect(response).to have_http_status :conflict
+    end
+
+    it "enqueues a job to notify a subscriber with a different role" do
+      create :subscriber, subscriber_type: "caseworker"
+      params = {
+        application_id: SecureRandom.uuid,
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
+
+      expect { post("/v1/submissions", params:) }.to have_enqueued_job
+    end
+
+    it "ignores subscribers with same roles as client" do
+      create :subscriber, subscriber_type: "provider"
+      params = {
+        application_id: SecureRandom.uuid,
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
+
+      expect { post("/v1/submissions", params:) }.not_to have_enqueued_job
+    end
   end
 
-  it "validates what I send" do
-    post "/v1/submissions", params: {
-      application_id: SecureRandom.uuid,
-    }
-    expect(response).to have_http_status :unprocessable_entity
-  end
+  context "when not using token" do
+    around do |example|
+      ENV["AUTHENTICATION_REQUIRED"] = "false"
+      example.run
+      ENV["AUTHENTICATION_REQUIRED"] = nil
+    end
 
-  it "detects conflicting information" do
-    submission = create(:submission)
-    post "/v1/submissions", params: {
-      application_id: submission.id,
-    }
-    expect(response).to have_http_status :conflict
-  end
+    it "enqueues a job to notify a subscriber with a different role" do
+      create :subscriber, subscriber_type: "caseworker"
+      params = {
+        application_id: SecureRandom.uuid,
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
 
-  it "enqueues a job to notify a subscriber with a different role" do
-    create :subscriber, subscriber_type: "caseworker"
-    params = {
-      application_id: SecureRandom.uuid,
-      application_type: "crm4",
-      application_risk: "low",
-      json_schema_version: 1,
-      application: { foo: :bar },
-    }
+      expect { post("/v1/submissions", params:, headers: { 'X-Client-Type': "provider" }) }.to have_enqueued_job
+    end
 
-    expect { post("/v1/submissions", params:) }.to have_enqueued_job
-  end
+    it "ignores subscribers with same roles as client" do
+      create :subscriber, subscriber_type: "provider"
+      params = {
+        application_id: SecureRandom.uuid,
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
 
-  it "ignores subscribers with same roles as client" do
-    create :subscriber, subscriber_type: "provider"
-    params = {
-      application_id: SecureRandom.uuid,
-      application_type: "crm4",
-      application_risk: "low",
-      json_schema_version: 1,
-      application: { foo: :bar },
-    }
-
-    expect { post("/v1/submissions", params:) }.not_to have_enqueued_job
+      expect { post("/v1/submissions", params:, headers: { 'X-Client-Type': "provider" }) }.not_to have_enqueued_job
+    end
   end
 end


### PR DESCRIPTION
## Description of change
- Another fix to ping endpoint to match postman expectations
- Handle Socket::ResolutionError the same way as other errors in NotifySubscriber
- Bump UAT and production pod resources to be able to handle a `rails c` alongside ` rails s`
- Allow puma to launch in cluster mode so we can handle a synchronous response to our webhook callbacks in E2E tests
- Use fallback request header to identify client role in non-auth setup.