### PR TITLE
CRM457-1146: Add authorization rules

### DIFF
--- a/app/controllers/V1/submissions_controller.rb
+++ b/app/controllers/V1/submissions_controller.rb
@@ -15,14 +15,22 @@ module V1
     end
 
     def show
-      render json: Submission.find(params[:id])
+      render json: current_submission
     end
 
     def update
-      Submissions::UpdateService.call(params, current_client_role)
+      Submissions::UpdateService.call(current_submission, params, current_client_role)
       head :created
     rescue ActiveRecord::RecordInvalid
       head :unprocessable_entity
+    end
+
+    def current_submission
+      @current_submission ||= Submission.find(params[:id])
+    end
+
+    def authorization_object
+      current_submission if action_name == "update"
     end
   end
 end

--- a/app/controllers/V1/subscribers_controller.rb
+++ b/app/controllers/V1/subscribers_controller.rb
@@ -12,10 +12,18 @@ module V1
     end
 
     def destroy
-      Subscriber.find_by(params.permit(:webhook_url, :subscriber_type)).destroy!
+      current_subscriber.destroy!
       head :no_content
     rescue ActiveRecord::StatementInvalid, NoMethodError
       head :not_found
+    end
+
+    def current_subscriber
+      @current_subscriber = Subscriber.find_by(params.permit(:webhook_url, :subscriber_type))
+    end
+
+    def authorization_object
+      current_subscriber if action_name == "destroy"
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   before_action :authenticate!
+  before_action :authorize!
 
   attr_reader :current_client_role
 
@@ -8,5 +9,21 @@ class ApplicationController < ActionController::API
     return head(:unauthorized) unless client_credentials[:valid]
 
     @current_client_role = client_credentials[:role]
+  end
+
+  def authorize!
+    allowed = AuthorizationService.call(
+      @current_client_role,
+      controller_name,
+      action_name,
+      params,
+      authorization_object,
+    )
+
+    head(:forbidden) unless allowed
+  end
+
+  def authorization_object
+    nil
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,5 +1,6 @@
 class HealthController < ApplicationController
   skip_before_action :authenticate!, only: :show
+  skip_before_action :authorize!, only: :show
 
   def show
     render json: build_args, status: :ok

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -1,0 +1,11 @@
+class AuthorizationService
+  def self.call(subject, category, verb, params, object)
+    rule = Authorization::Rules::PERMISSIONS.dig(subject, category.to_sym, verb.to_sym)
+
+    if rule.respond_to?(:call)
+      rule.call(object, params)
+    else
+      rule
+    end
+  end
+end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -1,8 +1,7 @@
 module Submissions
   class UpdateService
     class << self
-      def call(params, role)
-        submission = Submission.find(params[:id])
+      def call(submission, params, role)
         submission.with_lock do
           add_events(submission, params)
           submission.current_version += 1 if params[:application]

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Authentication" do
     end
 
     it "allows all requests" do
-      get "/v1/submissions"
+      get "/v1/submissions", headers: { "X-Client-Type" => "provider" }
       expect(response).to have_http_status :ok
     end
   end

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "Authorization" do
+  context "when authentication is not being done" do
+    around do |example|
+      ENV["AUTHENTICATION_REQUIRED"] = "false"
+      example.run
+      ENV.delete("AUTHENTICATION_REQUIRED")
+    end
+
+    it "allows requests based on the X-Client-Type" do
+      get "/v1/submissions", headers: { "X-Client-Type" => "provider" }
+      expect(response).to have_http_status :ok
+    end
+
+    it "denies requests without the X-Client-Type" do
+      get "/v1/submissions"
+      expect(response).to have_http_status :forbidden
+    end
+
+    it "denies requests if the client type cannot do the thing they want to do " do
+      post "/v1/submissions", headers: { "X-Client-Type" => "caseworker" }
+      # caseworkers cannot create submissions
+      expect(response).to have_http_status :forbidden
+    end
+
+    it "denies requests if the object is not in a state that permits modifications" do
+      submission = create(:submission, application_state: "granted")
+      # providers can only modify submissions that are in the 'sent_back' state
+      patch "/v1/submissions/#{submission.id}", headers: { "X-Client-Type" => "provider" }
+      expect(response).to have_http_status :forbidden
+    end
+
+    it "denies requests if the specific change requested is forbidden" do
+      submission = create(:submission, application_state: "submitted")
+      # caseworkers cannot mark submissions as provider_updated
+      patch "/v1/submissions/#{submission.id}",
+            params: { application_state: "provider_updated" },
+            headers: { "X-Client-Type" => "caseworker" }
+      expect(response).to have_http_status :forbidden
+    end
+  end
+
+  context "when a valid auth token is provided" do
+    let(:decoded) { [{ "azp" => client_id }] }
+
+    around do |example|
+      ENV["PROVIDER_CLIENT_ID"] = "PROVIDER"
+      ENV["CASEWORKER_CLIENT_ID"] = "CASEWORKER"
+      example.run
+      ENV["PROVIDER_CLIENT_ID"] = nil
+      ENV["CASEWORKER_CLIENT_ID"] = nil
+    end
+
+    before do
+      allow(Tokens::VerificationService).to receive(:parse).and_return(decoded)
+      allow(Tokens::VerificationService).to receive(:valid?).and_return(true)
+    end
+
+    context "when client is doing something it is allowed to based on its token" do
+      let(:client_id) { "CASEWORKER" }
+
+      it "allows them to do it" do
+        submission = create(:submission, application_state: "submitted")
+        patch "/v1/submissions/#{submission.id}",
+              headers: { "Authorization" => "Bearer ABC" },
+              params: { application_state: "granted" }
+        expect(response).to have_http_status :created
+      end
+    end
+
+    context "when client is doing something it is not allowed to based on its token" do
+      let(:client_id) { "PROVIDER" }
+
+      it "does not allow them to do it" do
+        submission = create(:submission, application_state: "submitted")
+        patch "/v1/submissions/#{submission.id}",
+              headers: { "Authorization" => "Bearer ABC" },
+              params: { application_state: "granted" }
+        expect(response).to have_http_status :forbidden
+      end
+    end
+  end
+end

--- a/spec/requests/delete_subscriber_spec.rb
+++ b/spec/requests/delete_subscriber_spec.rb
@@ -1,17 +1,29 @@
 require "rails_helper"
 
 RSpec.describe "DELETE /v1/subscribers" do
-  before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :provider) }
+  before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role:) }
+
+  let(:role) { :provider }
 
   it "deletes a record" do
-    subscriber = create :subscriber
+    subscriber = create :subscriber, subscriber_type: "provider"
     delete "/v1/subscribers", params: { webhook_url: subscriber.webhook_url, subscriber_type: subscriber.subscriber_type }
     expect(response).to have_http_status(:no_content)
     expect(Subscriber.count).to eq 0
   end
 
   it "handles missing records" do
-    delete "/v1/subscribers", params: { webhook_url: "a", subscriber_type: "b" }
+    delete "/v1/subscribers", params: { webhook_url: "a", subscriber_type: "provider" }
     expect(response).to have_http_status(:not_found)
+  end
+
+  context "when I have a different role to the one I am trying to delete" do
+    let(:role) { :caseworker }
+
+    it "prevents me from deleting subscribers not my own" do
+      subscriber = create :subscriber, subscriber_type: "provider"
+      delete "/v1/subscribers", params: { webhook_url: subscriber.webhook_url, subscriber_type: subscriber.subscriber_type }
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 end


### PR DESCRIPTION
## Description of change
- Add a set of rules of what providers and caseworkers can do
- Include what states they can change submissions to and from
- Authorize in a before_action according to the rules

## Link to relevant ticket

[CRM457-1146](https://dsdmoj.atlassian.net/browse/CRM457-1146)

[CRM457-1146]: https://dsdmoj.atlassian.net/browse/CRM457-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ