### PR TITLE
Use roles instead of knowing specific IDs

### DIFF
--- a/app/services/tokens/verification_service.rb
+++ b/app/services/tokens/verification_service.rb
@@ -47,13 +47,13 @@ module Tokens
       end
 
       def role_from(data)
-        case data[0]["azp"]
-        when ENV.fetch("PROVIDER_CLIENT_ID")
+        case data.dig(0, "roles", 0)
+        when "Provider"
           :provider
-        when ENV.fetch("CASEWORKER_CLIENT_ID")
+        when "Caseworker"
           :caseworker
         else
-          raise "Unrecognised client ID #{data[0]['aud']}"
+          raise "Unrecognised roles #{data[0]['roles']}"
         end
       end
     end

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -106,16 +106,6 @@ spec:
                 secretKeyRef:
                   name: azure-secret
                   key: client_secret
-            - name: PROVIDER_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-secret
-                  key: provider_client_id
-            - name: CASEWORKER_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-secret
-                  key: caseworker_client_id
             {{- if not (eq .Values.environment "prod") }}
             - name: AUTHENTICATION_REQUIRED
               value: {{ .Values.envVars.authenticationRequired | quote}}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -101,16 +101,6 @@ spec:
                 secretKeyRef:
                   name: azure-secret
                   key: client_secret
-            - name: PROVIDER_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-secret
-                  key: provider_client_id
-            - name: CASEWORKER_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: azure-secret
-                  key: caseworker_client_id
             {{- if not (eq .Values.environment "prod") }}
             - name: AUTHENTICATION_REQUIRED
               value: {{ .Values.envVars.authenticationRequired | quote}}

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe "Authentication" do
   context "when an auth token is provided" do
     around do |example|
       ENV["TENANT_ID"] = "TENANT"
+      ENV["APP_CLIENT_ID"] = "APP_STORE"
       example.run
       ENV["TENANT_ID"] = nil
+      ENV["APP_CLIENT_ID"] = nil
     end
 
     before do
@@ -50,20 +52,10 @@ RSpec.describe "Authentication" do
     context "when the token is valid" do
       let(:jwks) { instance_double(JWT::JWK::Set) }
       let(:decoded) do
-        [{ "azp" => client_id,
+        [{ "roles" => [role],
            "aud" => "APP_STORE",
            "iss" => "https://login.microsoftonline.com/TENANT/v2.0",
            "exp" => 1.hour.from_now.to_i }]
-      end
-
-      around do |example|
-        ENV["PROVIDER_CLIENT_ID"] = "PROVIDER"
-        ENV["CASEWORKER_CLIENT_ID"] = "CASEWORKER"
-        ENV["APP_CLIENT_ID"] = "APP_STORE"
-        example.run
-        ENV["PROVIDER_CLIENT_ID"] = nil
-        ENV["CASEWORKER_CLIENT_ID"] = nil
-        ENV["APP_CLIENT_ID"] = nil
       end
 
       before do
@@ -74,7 +66,7 @@ RSpec.describe "Authentication" do
       end
 
       context "when caseworker client id is provided" do
-        let(:client_id) { "CASEWORKER" }
+        let(:role) { "Caseworker" }
 
         it "allows the request" do
           expect(response).to have_http_status :ok
@@ -82,7 +74,7 @@ RSpec.describe "Authentication" do
       end
 
       context "when provider client id is provided" do
-        let(:client_id) { "PROVIDER" }
+        let(:role) { "Provider" }
 
         it "allows the request" do
           expect(response).to have_http_status :ok
@@ -90,7 +82,7 @@ RSpec.describe "Authentication" do
       end
 
       context "when unknown client id is provided" do
-        let(:client_id) { "UNKNOWN" }
+        let(:role) { "UNKNOWN" }
 
         it "rejects the request" do
           expect(response).to have_http_status :unauthorized

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -42,15 +42,7 @@ RSpec.describe "Authorization" do
   end
 
   context "when a valid auth token is provided" do
-    let(:decoded) { [{ "azp" => client_id }] }
-
-    around do |example|
-      ENV["PROVIDER_CLIENT_ID"] = "PROVIDER"
-      ENV["CASEWORKER_CLIENT_ID"] = "CASEWORKER"
-      example.run
-      ENV["PROVIDER_CLIENT_ID"] = nil
-      ENV["CASEWORKER_CLIENT_ID"] = nil
-    end
+    let(:decoded) { [{ "roles" => [role] }] }
 
     before do
       allow(Tokens::VerificationService).to receive(:parse).and_return(decoded)
@@ -58,7 +50,7 @@ RSpec.describe "Authorization" do
     end
 
     context "when client is doing something it is allowed to based on its token" do
-      let(:client_id) { "CASEWORKER" }
+      let(:role) { "Caseworker" }
 
       it "allows them to do it" do
         submission = create(:submission, application_state: "submitted")
@@ -70,7 +62,7 @@ RSpec.describe "Authorization" do
     end
 
     context "when client is doing something it is not allowed to based on its token" do
-      let(:client_id) { "PROVIDER" }
+      let(:role) { "Provider" }
 
       it "does not allow them to do it" do
         submission = create(:submission, application_state: "submitted")


### PR DESCRIPTION
## Description of change
Our Entra tokens now contain a "roles" array populated with either `["Provider"]` or `["Caseworker"]`. Using this means we don't need the app store to know the specific client IDs used by provider/caseworker apps, giving us more flexibility.