### PR TITLE
Change labels on worker deployment

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -10,7 +10,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "laa-crime-application-store.selectorLabels" . | nindent 6 }}
+      app:  {{ include "laa-crime-application-store.fullname" . }}-worker
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "laa-crime-application-store.selectorLabels" . | nindent 8 }}
+        app:  {{ include "laa-crime-application-store.fullname" . }}-worker
     spec:
       serviceAccountName: {{ .Values.service_account.name }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
How to verify this fixes stuff:

```
kubectl get pods -n laa-crime-application-store-dev
```

Pick any healthy pod that is neither named `routing-label` nor `laa-crime-application-store-app` and then run

```
kubectl exec -it <pod name> -n laa-crime-application-store-dev -- sh
```

From your shell, if you run the following several times, instead of giving you a 401 every time, it will sometimes give you a "connection refused" error:

```
wget http://laa-crime-application-store-app.laa-crime-application-store-dev.svc.cluster.local
```

This shows that on dev main (with service name `laa-crime-application-store-app`), requests that bypass the ingress are sometimes being routed to worker pods instead of web app pods.

However, if you instead run

```
wget http://routing-label.laa-crime-application-store-dev.svc.cluster.local
```

You should  always receive a 401. That's because it's pointing to this branch, where worker pods have different labels to web app pods, so incoming requests are never routed to them