### PR TITLE
CRM457-1430: Allow updating CRM7 RFI applications

### DIFF
--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -42,6 +42,7 @@ module Authorization
                    provider_requested
                    sent_back],
         },
+        { pre: %w[further_info provider_requested], post: %w[granted part_grant rejected] },
       ],
     }.freeze
 

--- a/spec/requests/update_submission_spec.rb
+++ b/spec/requests/update_submission_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Update submission" do
   end
 
   it "updates events" do
-    submission = create :submission
+    submission = create :submission, application_state: "further_info"
     patch "/v1/submissions/#{submission.id}",
           params: {
             application_state: "granted",


### PR DESCRIPTION
## Description of change
When an application is in 'further_info' or 'provider_requested' states (i.e. CRM7 that has been sent back), a caseworker can still assess them.

## Link to relevant ticket

[CRM457-1430](https://dsdmoj.atlassian.net/browse/CRM457-1430)
