### PR TITLE
Crm457 1561 fix modsec on metabase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ commands:
               kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
               kubectl config use-context ${K8S_CLUSTER_NAME}
               kubectl --namespace=${K8S_NAMESPACE} get pods
-      - deploy:
+      - run:
             name: Deploy to << parameters.environment >>
             command: |
               ./bin/deploy << parameters.environment >>

--- a/bin/deploy
+++ b/bin/deploy
@@ -13,7 +13,7 @@ deploy_branch() {
   echo "Deploying under release name: '$BRANCH_RELEASE_NAME' with identifier '$IDENTIFIER'..."
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/. \
-                --install --wait \
+                --install --wait --timeout 15m0s --debug\
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/values-development.yaml \
                 --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \
@@ -27,7 +27,7 @@ deploy_branch() {
 
 deploy_main() {
   helm upgrade laa-crime-application-store ./helm_deploy/. \
-                          --install --wait \
+                          --install --wait --timeout 15m0s --debug\
                           --namespace=${K8S_NAMESPACE} \
                           --values ./helm_deploy/values-$ENVIRONMENT.yaml \
                           --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \

--- a/bin/deploy
+++ b/bin/deploy
@@ -13,7 +13,7 @@ deploy_branch() {
   echo "Deploying under release name: '$BRANCH_RELEASE_NAME' with identifier '$IDENTIFIER'..."
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/. \
-                --install --wait --timeout 15m0s --debug\
+                --install --wait --timeout 10m0s --debug\
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/values-development.yaml \
                 --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \

--- a/bin/deploy
+++ b/bin/deploy
@@ -13,7 +13,7 @@ deploy_branch() {
   echo "Deploying under release name: '$BRANCH_RELEASE_NAME' with identifier '$IDENTIFIER'..."
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/. \
-                --install --wait --timeout 10m0s --debug\
+                --install --wait --timeout 10m0s \
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/values-development.yaml \
                 --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -20,7 +20,9 @@ spec:
       labels:
         app:  {{ include "laa-crime-application-store.fullname" . }}-worker
     spec:
+      {{ if .Values.service_account.required }}
       serviceAccountName: {{ .Values.service_account.name }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -20,7 +20,9 @@ spec:
       labels:
         {{- include "laa-crime-application-store.selectorLabels" . | nindent 8 }}
     spec:
+      {{ if .Values.service_account.required }}
       serviceAccountName: {{ .Values.service_account.name }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/metabase/deployment.yaml
+++ b/helm_deploy/templates/metabase/deployment.yaml
@@ -18,7 +18,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      {{ if .Values.service_account.required }}
       serviceAccountName: {{ .Values.service_account.name }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm_deploy/templates/metabase/deployment.yaml
+++ b/helm_deploy/templates/metabase/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: metabase
-        image: metabase/metabase:v0.49.3
+        image: metabase/metabase:v0.49.13
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
           - containerPort: 3000

--- a/helm_deploy/templates/metabase/ingress.yaml
+++ b/helm_deploy/templates/metabase/ingress.yaml
@@ -11,8 +11,9 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=ministryofjustice/laa-crime-forms-team"
-      SecDefaultAction "phase:4,pass,log,tag:github_team=ministryofjustice/laa-crime-forms-team"
+      SecRequestBodyNoFilesLimit 524288
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
 spec:
   ingressClassName: modsec
   tls:

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -65,6 +65,7 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 
 service_account:
+  required: false
   name: laa-crime-application-store-dev-irsa
 
 envVars:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -57,6 +57,7 @@ tolerations: []
 affinity: {}
 
 service_account:
+  required: true
   name: laa-crime-application-store-production-irsa
 
 envVars:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -57,6 +57,7 @@ tolerations: []
 affinity: {}
 
 service_account:
+  required: true
   name: laa-crime-application-store-uat-irsa
 
 envVars:


### PR DESCRIPTION
## Description of change

## Link to relevant ticket

[CRM457-1561](https://dsdmoj.atlassian.net/browse/CRM457-1561)

## Notes for reviewer

Modsec in basic setup doesn't permit metabase to work. Rather than switch it off completely have mirrored the setup from  [crime apply](https://github.com/ministryofjustice/laa-criminal-applications-datastore/blob/fde2f61b8002e6de5bf1e943673805e554d3875b/config/kubernetes/metabase/ingress.yml#L19) but adjusted the parameters to match the settings we have for modsec in dev of [laa-assess-crime-forms](https://github.com/ministryofjustice/laa-assess-crime-forms/blob/356031514a6a221fcc4b0762e884cc5d97d91eeb/helm_deploy/values-dev.yaml#L29)

Note that this is the same as other environments except for the filesize limit which should be updated to be the same as dev.

Also 

- updated deprecated deploy step to run
- added extra time for the helm deploy to hopefully reduce timeouts
- had to remove mention of service account in dev deployments as it is not needed (will use default service account) as we don't have any aws resources in that environment 


## Screenshots of changes (if applicable)
Example of Issue to be fixed (can't check fixed until merged to UAT):
<img width="1070" alt="Screenshot 2024-05-30 at 17 36 05" src="https://github.com/ministryofjustice/laa-crime-application-store/assets/3441835/77652a8c-05c1-49f0-8707-30a0d70f185b">


### Before changes:

### After changes:

## How to manually test the feature

[CRM457-1561]: https://dsdmoj.atlassian.net/browse/CRM457-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ