### PR TITLE
CRM457-1457: Grafana tweak

### DIFF
--- a/helm_deploy/dashboards/grafana-rails-metrics.yml
+++ b/helm_deploy/dashboards/grafana-rails-metrics.yml
@@ -159,7 +159,7 @@ data:
           "pluginVersion": "9.2.4",
           "targets": [
             {
-              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[60m]) * 60 * 60)",
+              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[60m]) * 60 * 60)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -271,7 +271,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (controller,action) (rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m])  > 0)\n/\navg by (controller,action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0) * 1000",
+              "expr": "avg by (controller,action) (rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m])  > 0)\n/\navg by (controller,action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0) * 1000",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -371,7 +371,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by (controller, action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\", controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "sum by (controller, action) (rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\", controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{controller}}/{{action}}",
@@ -426,7 +426,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "max(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -436,7 +436,7 @@ data:
               "target": "carbon.*"
             },
             {
-              "expr": "max(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "max(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max SQL",
@@ -517,7 +517,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",status=~\"^[23].*\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m])) by (status) > 0",
+              "expr": "sum(rate(ruby_http_requests_total{namespace=\"$namespace\",status=~\"^[23].*\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m])) by (status) > 0",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{status}}",
@@ -602,7 +602,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "avg(rate(ruby_http_request_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Avg Request",
@@ -610,7 +610,7 @@ data:
               "target": ""
             },
             {
-              "expr": "avg(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
+              "expr": "avg(rate(ruby_http_request_sql_duration_seconds_sum{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) / rate(ruby_http_request_sql_duration_seconds_count{namespace=\"$namespace\",controller!~'.*health.*',controller=~\"$controller\",action=~\"$action\"}[5m]) > 0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Avg SQL",
@@ -968,7 +968,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "topk(10,sum(rate(ruby_http_request_duration_seconds_count{namespace=~\"$namespace\",controller!~'.*health'}[1w]) * 3600 * 24) by (controller, action))",
+              "expr": "topk(10,sum(rate(ruby_http_request_duration_seconds_count{namespace=~\"$namespace\",controller!~'.*health.*'}[1w]) * 3600 * 24) by (controller, action))",
               "format": "table",
               "instant": true,
               "intervalFactor": 1,


### PR DESCRIPTION
## Description of change
Accommodate different healthcheck controller names across apps (in provider and caseworker the health controller is called healthcheck, not health)

## Link to relevant ticket

[CRM457-1457](https://dsdmoj.atlassian.net/browse/CRM457-1457)

[CRM457-1457]: https://dsdmoj.atlassian.net/browse/CRM457-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ