### PR TITLE
Add timestamps to tables

### DIFF
--- a/db/migrate/20240617104514_add_time_stamps_to_application_and_application_version.rb
+++ b/db/migrate/20240617104514_add_time_stamps_to_application_and_application_version.rb
@@ -1,0 +1,7 @@
+class AddTimeStampsToApplicationAndApplicationVersion < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application, :created_at, :datetime, precision: nil
+    add_column :application_version, :created_at, :datetime, precision: nil
+    add_column :application_version, :updated_at, :datetime, precision: nil
+  end
+end

--- a/db/migrate/20240617105727_backfill_time_stamps_on_application_and_application_version.rb
+++ b/db/migrate/20240617105727_backfill_time_stamps_on_application_and_application_version.rb
@@ -1,0 +1,34 @@
+class BackfillTimeStampsOnApplicationAndApplicationVersion < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    # Update Submissions without events to have created_at the same as updated_at
+    Submission.unscoped.where(created_at: nil, events: nil).in_batches do |relation|
+      relation.update_all("created_at = updated_at")
+      sleep 0.1
+    end
+
+    # Update Submissions with events to have created_at matching earliest/first events created_at (new_version||auto_decision)
+    Submission.unscoped.where(created_at: nil).where.not(events: nil).each do |submission|
+      created_at = submission.events.first['created_at'].in_time_zone
+
+      submission.update_columns(created_at:)
+      sleep 0.01
+    end
+
+    # Update SubmissionsVersions with version: 1 to have created_at and updated_at matching the created_at date for their application as set above
+    sql = <<~SQL
+      UPDATE application_version as app_v
+      SET created_at = app.created_at,
+          updated_at = app.created_at
+      FROM application as app
+      WHERE app.id = app_v.application_id
+        AND app_v.version = 1
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    # Update SubmissionsVersions with version: 2+ to have created_at/updated_at matching the created_at ????
+    # LEFT OUT as there is no reliable way to map events to submission versions.
+  end
+end

--- a/db/migrate/20240617131805_add_not_null_constraints_to_time_stamps.rb
+++ b/db/migrate/20240617131805_add_not_null_constraints_to_time_stamps.rb
@@ -1,0 +1,7 @@
+class AddNotNullConstraintsToTimeStamps < ActiveRecord::Migration[7.1]
+  # Reference: https://github.com/ankane/strong_migrations?tab=readme-ov-file#good-14
+  def change
+    add_check_constraint :application, "updated_at IS NOT NULL", name: "application_updated_at_null", validate: false
+    add_check_constraint :application, "created_at IS NOT NULL", name: "application_created_at_null", validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_092435) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_131805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_092435) do
     t.text "application_type", null: false
     t.datetime "updated_at", precision: nil
     t.jsonb "events"
+    t.datetime "created_at", precision: nil
+    t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null", validate: false
+    t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null", validate: false
   end
 
   create_table "application_version", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -28,6 +31,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_092435) do
     t.integer "version", null: false
     t.integer "json_schema_version", null: false
     t.jsonb "application", null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
   end
 
   create_table "subscriber", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
Add timestamps to table

[relates to ticket](https://dsdmoj.atlassian.net/browse/CRM457-1487)

Timestamps for applications and application versions give us easy to access
dates that are of value for stats and dashboard. e.g. application.created_at would
be the datetime an application was submitted.

These have not been added due to python/alembic not doing it by default, unlike rails


## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature