### PR TITLE
End to End Test Required to Pass Before any Deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,11 +336,11 @@ workflows:
       - deploy-dev:
           context: laa-crime-application-store-dev
           requires:
-              - build-and-push
+              - e2e-test-main
       - deploy-uat:
           context: laa-crime-application-store-uat
           requires:
-            - build-and-push
+            - e2e-test-main
           filters:
               branches:
                   only:


### PR DESCRIPTION
## Description of change

## Link to relevant ticket

[End to End tests block deployment to production](https://dsdmoj.atlassian.net/browse/CRM457-1578)
## Notes for reviewer
Ticket only explicitly says to block deployment to production but decided to also block deployment to dev and uat because otherwise we have to manually rollback afterwards and we shouldn't have faulty code in UAT