### PR TITLE
Associate TLS certificate to metabase ingress

### DIFF
--- a/helm_deploy/templates/metabase/ingress.yaml
+++ b/helm_deploy/templates/metabase/ingress.yaml
@@ -19,6 +19,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.metabase.url }}
+      secretName: {{ Values.metabase.ingress.tls.secretName }}
   rules:
   - host: {{ .Values.metabase.url }}
     http:

--- a/helm_deploy/templates/metabase/ingress.yaml
+++ b/helm_deploy/templates/metabase/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.metabase.url }}
-      secretName: {{ Values.metabase.ingress.tls.secretName }}
+      secretName: {{ .Values.metabase.ingress.tls.secretName }}
   rules:
   - host: {{ .Values.metabase.url }}
     http:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -69,7 +69,7 @@ redis:
 
 metabase:
   enabled: false
-  url: "uat.crime-forms-metabase.service.justice.gov.uk"
+  url: "crime-forms-metabase.service.justice.gov.uk"
   service:
     port: 80
     internalPort: 3000

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -75,3 +75,5 @@ metabase:
     internalPort: 3000
   ingress:
     namespace: laa-crime-application-store-prod
+    tls:
+      secretName: laa-crime-application-store-cert

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -76,3 +76,5 @@ metabase:
     internalPort: 3000
   ingress:
     namespace: laa-crime-application-store-uat
+    tls:
+      secretName: laa-crime-application-store-cert


### PR DESCRIPTION
## Description of change

[Add TLS cert and custom domain for metabase deployments in app store](https://dsdmoj.atlassian.net/browse/CRM457-1546)

## Notes for reviewer
The TLS certificate had been created but not associated to ingress - this fixes that