### PR TITLE
[CRM457-1664] allow events only to be updated

### DIFF
--- a/app/controllers/V1/events_controller.rb
+++ b/app/controllers/V1/events_controller.rb
@@ -5,7 +5,7 @@ module V1
       head :created
     end
 
-    private
+  private
 
     def current_submission
       @current_submission ||= Submission.find(params[:submission_id])

--- a/app/controllers/V1/events_controller.rb
+++ b/app/controllers/V1/events_controller.rb
@@ -1,0 +1,18 @@
+module V1
+  class EventsController < ApplicationController
+    def create
+      Submissions::UpdateService.add_events(current_submission, params, save: true)
+      head :created
+    end
+
+    private
+
+    def current_submission
+      @current_submission ||= Submission.find(params[:submission_id])
+    end
+
+    def authorization_object
+      current_submission
+    end
+  end
+end

--- a/app/controllers/V1/submissions_controller.rb
+++ b/app/controllers/V1/submissions_controller.rb
@@ -21,8 +21,8 @@ module V1
     def update
       Submissions::UpdateService.call(current_submission, params, current_client_role)
       head :created
-    rescue ActiveRecord::RecordInvalid
-      head :unprocessable_entity
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { errors: e.message }, status: :unprocessable_entity
     end
 
     def current_submission

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -51,8 +51,7 @@ module Authorization
 
     def self.state_pair_allowed?(object, params, pairs)
       pairs.any? do |pair|
-        object.application_state.in?(pair[:pre]) && params[:application_state].in?(pair[:post]) &&
-          (pair[:criteria].nil? || pair[:criteria].call(params))
+        object.application_state.in?(pair[:pre]) && params[:application_state].in?(pair[:post])
       end
     end
   end

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -43,12 +43,14 @@ module Authorization
                    sent_back],
         },
         { pre: %w[further_info provider_requested], post: %w[granted part_grant rejected] },
+        { pre: %w[submitted provider_updated], post: [nil], criteria: ->(params) { params[:application].nil? } }
       ],
     }.freeze
 
     def self.state_pair_allowed?(object, params, pairs)
       pairs.any? do |pair|
-        object.application_state.in?(pair[:pre]) && params[:application_state].in?(pair[:post])
+        object.application_state.in?(pair[:pre]) && params[:application_state].in?(pair[:post]) &&
+          (pair[:criteria].nil? || pair[:criteria].call(params))
       end
     end
   end

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -23,6 +23,9 @@ module Authorization
           show: true,
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:caseworker]) },
         },
+        events: {
+          create: ->(object, _params) { object.application_state.in?(%w[submitted provider_updated]) }
+        }
       },
     }.freeze
 
@@ -43,7 +46,6 @@ module Authorization
                    sent_back],
         },
         { pre: %w[further_info provider_requested], post: %w[granted part_grant rejected] },
-        { pre: %w[submitted provider_updated], post: [nil], criteria: ->(params) { params[:application].nil? } },
       ],
     }.freeze
 

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -43,7 +43,7 @@ module Authorization
                    sent_back],
         },
         { pre: %w[further_info provider_requested], post: %w[granted part_grant rejected] },
-        { pre: %w[submitted provider_updated], post: [nil], criteria: ->(params) { params[:application].nil? } }
+        { pre: %w[submitted provider_updated], post: [nil], criteria: ->(params) { params[:application].nil? } },
       ],
     }.freeze
 

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -24,8 +24,8 @@ module Authorization
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:caseworker]) },
         },
         events: {
-          create: ->(object, _params) { object.application_state.in?(%w[submitted provider_updated]) }
-        }
+          create: ->(object, _params) { object.application_state.in?(%w[submitted provider_updated]) },
+        },
       },
     }.freeze
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => "/sidekiq"
 
   namespace "v1" do
-    resources :submissions, only: %i[show create index update]
+    resources :submissions, only: %i[show create index update] do
+      resources :events, only: %i[create]
+    end
     resources :subscribers, only: %i[create]
     delete :subscribers, to: "subscribers#destroy"
 

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Authorization" do
         submission = create(:submission, application_state: "submitted")
         patch "/v1/submissions/#{submission.id}",
               headers: { "Authorization" => "Bearer ABC" },
-              params: { application_state: "granted" }
+              params: { application_state: "granted", application: { new: :data }, json_schema_version: 1 }
         expect(response).to have_http_status :created
       end
     end

--- a/spec/requests/create_events_spec.rb
+++ b/spec/requests/create_events_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Create events" do
+  context "when authenticated with bearer token" do
+    let(:submission) { create(:submission, application_state:) }
+    let(:application_state) { 'submitted' }
+
+    before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :caseworker) }
+
+    it "saves what I send" do
+      post "/v1/submissions/#{submission.id}/events", params: {
+        events: [
+          {
+            id: "A",
+            details: "history",
+          }
+        ],
+      }
+      expect(response).to have_http_status :created
+
+      expect(submission.reload.events).to match([
+        {
+          "id" => "A",
+          "details" => "history",
+        }
+      ])
+    end
+
+    it "does not overwrite existing events" do
+      submission.update(events: [{ id: "A", details: "actual history" }])
+      post "/v1/submissions/#{submission.id}/events", params: {
+        events: [
+          {
+            id: "A",
+            details: "history",
+          }
+        ],
+      }
+      expect(response).to have_http_status :created
+      expect(submission.reload.events).to match([
+        {
+          "id" => "A",
+          "details" => "actual history",
+        }
+      ])
+    end
+
+    it "does not increament the version" do
+      post "/v1/submissions/#{submission.id}/events", params: {
+        events: [
+          {
+            id: "A",
+            details: "history",
+          }
+        ],
+      }
+      expect(response).to have_http_status :created
+      expect(submission.reload.current_version).to eq(1)
+    end
+
+    it "not not allow update of application_state" do
+      post "/v1/submissions/#{submission.id}/events", params: {
+        application_state: "granted",
+        events: [
+          {
+            id: "A",
+            details: "history",
+          }
+        ],
+      }
+      expect(response).to have_http_status :created
+      expect(submission.reload.application_state).to eq("submitted")
+    end
+  end
+end

--- a/spec/requests/create_events_spec.rb
+++ b/spec/requests/create_events_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Create events" do
   context "when authenticated with bearer token" do
     let(:submission) { create(:submission, application_state:) }
-    let(:application_state) { 'submitted' }
+    let(:application_state) { "submitted" }
 
     before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :caseworker) }
 
@@ -13,7 +13,7 @@ RSpec.describe "Create events" do
           {
             id: "A",
             details: "history",
-          }
+          },
         ],
       }
       expect(response).to have_http_status :created
@@ -22,18 +22,18 @@ RSpec.describe "Create events" do
         {
           "id" => "A",
           "details" => "history",
-        }
+        },
       ])
     end
 
     it "does not overwrite existing events" do
-      submission.update(events: [{ id: "A", details: "actual history" }])
+      submission.update!(events: [{ id: "A", details: "actual history" }])
       post "/v1/submissions/#{submission.id}/events", params: {
         events: [
           {
             id: "A",
             details: "history",
-          }
+          },
         ],
       }
       expect(response).to have_http_status :created
@@ -41,7 +41,7 @@ RSpec.describe "Create events" do
         {
           "id" => "A",
           "details" => "actual history",
-        }
+        },
       ])
     end
 
@@ -51,7 +51,7 @@ RSpec.describe "Create events" do
           {
             id: "A",
             details: "history",
-          }
+          },
         ],
       }
       expect(response).to have_http_status :created
@@ -65,7 +65,7 @@ RSpec.describe "Create events" do
           {
             id: "A",
             details: "history",
-          }
+          },
         ],
       }
       expect(response).to have_http_status :created

--- a/spec/requests/update_submission_spec.rb
+++ b/spec/requests/update_submission_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "Update submission" do
                 details: "foo",
               },
             ],
-            application:  { new: :data },
-            json_schema_version: 1
+            application: { new: :data },
+            json_schema_version: 1,
           }
 
     submission.reload
@@ -32,7 +32,7 @@ RSpec.describe "Update submission" do
       "id" => "123",
       "details" => "foo",
     )
-    expect(submission.application_state).to eq('granted')
+    expect(submission.application_state).to eq("granted")
     expect(submission.ordered_submission_versions.count).to eq(2)
   end
 
@@ -54,7 +54,7 @@ RSpec.describe "Update submission" do
       "id" => "123",
       "details" => "foo",
     )
-    expect(submission.application_state).to eq('submitted')
+    expect(submission.application_state).to eq("submitted")
     expect(submission.ordered_submission_versions.count).to eq(1)
   end
 

--- a/spec/requests/update_submission_spec.rb
+++ b/spec/requests/update_submission_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe "Update submission" do
     submission = create(:submission)
     patch "/v1/submissions/#{submission.id}", params: { application_state: "granted", application: { new: :data }, json_schema_version: nil }
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)).to eq("errors" => "Validation failed: Json schema version can't be blank")
+    expect(response.parsed_body).to eq("errors" => "Validation failed: Json schema version can't be blank")
   end
 
   it "validates 'application'" do
     submission = create(:submission)
     patch "/v1/submissions/#{submission.id}", params: { application_state: "granted", application: nil, json_schema_version: 1 }
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(JSON.parse(response.body)).to eq("errors" => "Validation failed: Application can't be blank")
+    expect(response.parsed_body).to eq("errors" => "Validation failed: Application can't be blank")
   end
 
   it "enqueues a notification to subscribers" do


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1664)

## Notes for reviewer
When looking at this I initially planned to add a new endpoint, but when looking at the existing code I realised it was already allow (almost) in the current endpoint so chose to modify the rules instead.

Happy to chnage to have a separate endpoint if people feel strongly