### PR TITLE
CMR457-1360: Add sidekiq metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/s
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk
 RUN apk add --force-overwrite glibc-$GLIBC_VERSION.apk
 
+# use local time zone to prevent issues with metrics
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
 FROM base AS dependencies
 
 # system dependencies required to build some gems

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -2,32 +2,36 @@
 return unless ENV.fetch("ENABLE_PROMETHEUS_EXPORTER", "false") == "true"
 
 require "prometheus_exporter/server"
+require "prometheus_exporter/instrumentation"
+require "prometheus_exporter/middleware"
 
 DEFAULT_PREFIX = "ruby_".freeze
+DEFAULT_BIND_ADDRESS = "0.0.0.0".freeze
+DEFAULT_PORT = 9394
 
 # We are running puma in single process mode, so this is safe
 # If we move to multi process mode, we will have to run the
 # exporter process separately (`bundle exec prometheus_exporter`)
 def start_prometheus_server
   server = PrometheusExporter::Server::WebServer.new(
-    bind: "0.0.0.0", port: ENV.fetch("PROMETHEUS_EXPORTER_PORT", 9394).to_i,
+    bind: ENV.fetch("PROMETHEUS_EXPORTER_HOST", DEFAULT_BIND_ADDRESS),
+    port: ENV.fetch("PROMETHEUS_EXPORTER_PORT", DEFAULT_PORT).to_i,
     verbose: ENV.fetch("PROMETHEUS_EXPORTER_VERBOSE", "false") == "true"
   )
 
   server.start
-
-  true
+  server
 rescue Errno::EADDRINUSE
   warn "[PrometheusExporter] Server port already in use."
   false
 end
 
-return unless start_prometheus_server
+Rails.logger.info("[PrometheusExporter] Starting server....")
+server = start_prometheus_server
+return unless server
 
-require "prometheus_exporter/instrumentation"
-require "prometheus_exporter/middleware"
-
-Rails.logger.info "[PrometheusExporter] Initialising instrumentation middleware..."
+Rails.logger.info("[PrometheusExporter] server started on #{JSON.parse(server.to_json).fetch_values('port', 'bind')}!")
+Rails.logger.info("[PrometheusExporter] Initialising standard instrumentation middleware...")
 
 # Metrics will be prefixed, for example `ruby_http_requests_total`
 PrometheusExporter::Metric::Base.default_prefix = DEFAULT_PREFIX
@@ -35,11 +39,17 @@ PrometheusExporter::Metric::Base.default_prefix = DEFAULT_PREFIX
 # This reports stats per request like HTTP status and timings
 Rails.application.middleware.unshift PrometheusExporter::Middleware
 
-# This reports basic process stats like RSS and GC info, type master
-# means it is instrumenting the master process
-PrometheusExporter::Instrumentation::Process.start(type: "master")
+# NOTE: if running Puma in cluster mode, the following instrumentation will need to be
+# moved to an after_worker_boot block in puma config.
+# NOTE: attempting to instrument puma prom export on sidekiq servers will result in lots of error logs
+#
+unless Sidekiq.server?
+  # This reports basic process stats like RSS and GC info, type master
+  # means it is instrumenting the master process.
+  # see config/puma.rb  after_work_boot for more
+  #
+  PrometheusExporter::Instrumentation::Process.start(type: "master")
 
-# NOTE: if running Puma in cluster mode, the following
-# instrumentation will need to be changed
-PrometheusExporter::Instrumentation::Puma.start unless PrometheusExporter::Instrumentation::Puma.started?
-PrometheusExporter::Instrumentation::ActiveRecord.start
+  PrometheusExporter::Instrumentation::Puma.start unless PrometheusExporter::Instrumentation::Puma.started?
+  PrometheusExporter::Instrumentation::ActiveRecord.start
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,10 +13,39 @@ if ENV["REDIS_HOST"].present? && ENV["REDIS_PASSWORD"].present?
                                                             nil)}:6379"
 end
 
+Rails.logger.info("[Sidekiq] Application config initialising...")
+
 Sidekiq.configure_client do |config|
+  Rails.logger.info("[SidekiqClient] configuring sidekiq client...")
   config.redis = { url: redis_url } if redis_url
 end
 
 Sidekiq.configure_server do |config|
+  Rails.logger.info("[SidekiqServer] configuring sidekiq server...")
   config.redis = { url: redis_url } if redis_url
+
+  return unless ENV.fetch("ENABLE_PROMETHEUS_EXPORTER", "false") == "true"
+
+  require 'prometheus_exporter/client'
+  require 'prometheus_exporter/instrumentation'
+
+  # Taken from https://github.com/discourse/prometheus_exporter?tab=readme-ov-file#sidekiq-metrics
+  #
+  config.server_middleware do |chain|
+    Rails.logger.info "[SidekiqPrometheusExporter] Chaining middleware..."
+    chain.add PrometheusExporter::Instrumentation::Sidekiq
+  end
+  config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+  config.on :startup do
+    Rails.logger.info "[SidekiqPrometheusExporter] Startup instrumention details..."
+
+    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+    PrometheusExporter::Instrumentation::SidekiqProcess.start
+    PrometheusExporter::Instrumentation::SidekiqQueue.start(all_queues: true)
+    PrometheusExporter::Instrumentation::SidekiqStats.start
+  end
+
+  at_exit do
+    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
+  end
 end

--- a/helm_deploy/templates/_helpers.tpl
+++ b/helm_deploy/templates/_helpers.tpl
@@ -48,7 +48,10 @@ Selector labels
 {{- define "laa-crime-application-store.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "laa-crime-application-store.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{/* This label allows the allow-prometheus-scraping NetworkPolicy to identify pods that expose prometheus metrics */}}
+{{/*
+TODO: Not needed anymore but removing causes immutable label problem
+This label allows the allow-prometheus-scraping NetworkPolicy to identify pods that expose prometheus metrics
+*/}}
 app: laa-crime-application-store-prometheus
 {{- end }}
 

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       labels:
         app:  {{ include "laa-crime-application-store.fullname" . }}-worker
+        metrics-target: {{ include "laa-crime-application-store.fullname" . }}-metrics-target
     spec:
       {{ if .Values.service_account.required }}
       serviceAccountName: {{ .Values.service_account.name }}
@@ -45,6 +46,7 @@ spec:
             - name: http
               containerPort: 7433
               protocol: TCP
+            - containerPort: 9394
           livenessProbe:
             httpGet:
               path: /
@@ -149,7 +151,8 @@ spec:
           {{ end }}
             - name: SUBSCRIBER_FAILED_ATTEMPT_DELETION_THRESHOLD
               value: '{{ .Values.envVars.subscriberFailedAttemptDeletionThreshold }}'
-
+            - name: ENABLE_PROMETHEUS_EXPORTER
+              value: 'true'
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "laa-crime-application-store.selectorLabels" . | nindent 8 }}
+        metrics-target: {{ include "laa-crime-application-store.fullname" . }}-metrics-target
     spec:
       {{ if .Values.service_account.required }}
       serviceAccountName: {{ .Values.service_account.name }}

--- a/helm_deploy/templates/network-policy.yaml
+++ b/helm_deploy/templates/network-policy.yaml
@@ -1,0 +1,18 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "laa-crime-application-store.fullname" . }}-allow-prometheus-scraping-netpol
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "laa-crime-application-store.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      metrics-target: {{ include "laa-crime-application-store.fullname" . }}-metrics-target
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: monitoring

--- a/helm_deploy/templates/service-monitor.yaml
+++ b/helm_deploy/templates/service-monitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "laa-crime-application-store.fullname" . }}-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      service: {{ include "laa-crime-application-store.fullname" . }}-metrics-svc
+  endpoints:
+  - port: metrics
+    interval: 15s

--- a/helm_deploy/templates/service.yaml
+++ b/helm_deploy/templates/service.yaml
@@ -17,14 +17,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "laa-crime-application-store.fullname" . }}-prometheus
+  name: {{ include "laa-crime-application-store.fullname" . }}-metrics-svc
   labels:
     app: laa-crime-application-store-prometheus
+    service: {{ include "laa-crime-application-store.fullname" . }}-metrics-svc
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: 9394
       name: metrics
-      targetPort: 9394
+      protocol: TCP
   selector:
-    {{- include "laa-crime-application-store.selectorLabels" . | nindent 4 }}
+    metrics-target: {{ include "laa-crime-application-store.fullname" . }}-metrics-target


### PR DESCRIPTION
## Description of change
Add sidekiq metrics to prometheus

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1360)

To visualize and alert on as required


- [X] Add sidekiq metrics instrumentation
- [x] add service monitor, service and network policies needed for metrics collection
- [x] add service account permissions in cloud platform environments
- [x] test on CP's prometheus monitoring toolstack

## Post merge tidy up

- [ ] remove unneeded network policies from CP - [example in DEV](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/04-networkpolicy.yaml#L44-L76)
- [ ] remove unneeded service monitors from CP - [example in DEV](namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-dev/05-servicemonitor.yaml)
- [ ] delete unused service monitor, smon, from kubernetes namespaces (kubectl delete smon <name>) - there is an old one
- [x] ensure branch built network policies are deleted on branch merge and delete (check)
- [ ] document

## Testing 

- You can test standard metrics are available on the branch using [this prometheus query](https://prometheus.cloud-platform.service.justice.gov.uk/graph?g0.expr=avg(ruby_http_request_duration_seconds%7Bnamespace%3D%22laa-crime-application-store-dev%22%7D)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=12h)

- You can test sidekiq metrics are available on the branch using [this prometheus query](https://prometheus.cloud-platform.service.justice.gov.uk/graph?g0.expr=ruby_sidekiq_stats_processed%7Bnamespace%3D%22laa-crime-application-store-dev%22%7D&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h)
