### PR TITLE
Crm457 1630/fix broken events

### DIFF
--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -3,8 +3,8 @@ module Submissions
     class << self
       def call(submission, params, role)
         submission.with_lock do
-          add_events(submission, params)
           submission.current_version += 1
+          add_events(submission, params)
           submission.update!(params.permit(:application_state, :application_risk))
           add_new_version(submission, params)
         end
@@ -15,6 +15,10 @@ module Submissions
         submission.events ||= []
         params[:events]&.each do |event|
           next if submission.events.any? { _1["id"] == event["id"] }
+
+          event["submission_version"] ||= submission.current_version
+          event["created_at"] ||= Time.zone.now
+          event["updated_at"] ||= event["created_at"]
 
           submission.events << event.as_json
         end

--- a/db/migrate/20240628155626_missing_event_fields.rb
+++ b/db/migrate/20240628155626_missing_event_fields.rb
@@ -1,7 +1,7 @@
 class MissingEventFields < ActiveRecord::Migration[7.1]
   def change
     Submission
-      .where("events @> '[{\"event_type\": \"provider_updated\"}]'").
+      .where("events @> '[{\"event_type\": \"provider_updated\"}]'")
       .each do |submission|
         last_version = nil
         submission.events.each do |event|

--- a/db/migrate/20240628155626_missing_event_fields.rb
+++ b/db/migrate/20240628155626_missing_event_fields.rb
@@ -1,0 +1,23 @@
+class MissingEventFields < ActiveRecord::Migration[7.1]
+  def change
+    Submission
+      .where("events @> '[{\"event_type\": \"provider_updated\"}]'").
+      .each do |submission|
+        last_version = nil
+        submission.events.each do |event|
+          last_version = [last_version, event["submission_version"]].compact.max
+
+          next if event["created_at"]
+          next unless event["event_type"] == 'provider_updated'
+
+          event["submission_version"] = last_version + 1
+          version = submission.ordered_submission_versions.detect { _1.version == event["submission_version"] }
+
+          event["created_at"] ||= version.created_at
+          event["updated_at"] ||= version.created_at
+        end
+
+        submission.save
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_26_140513) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_155626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,5 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+AnalyticsCreator.run

--- a/spec/requests/create_events_spec.rb
+++ b/spec/requests/create_events_spec.rb
@@ -20,8 +20,11 @@ RSpec.describe "Create events" do
 
       expect(submission.reload.events).to match([
         {
-          "id" => "A",
+          "created_at" => an_instance_of(String),
           "details" => "history",
+          "id" => "A",
+          "submission_version" => 1,
+          "updated_at" => an_instance_of(String),
         },
       ])
     end


### PR DESCRIPTION
## Description of change
Ensure version, created_at adn updated_at are set on all events (on creation)

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1630)

## Notes for reviewer
Ideally the provider_updated event should also have a user ID on it... but this is not a app store concern so have left out for now... this would also likely break the CW app as they wouldn't know the user ID