### PR TITLE
CRM457-1529: Change snyk scanning approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  snyk: snyk/snyk@1.1.2
+  snyk: snyk/snyk@2.1.0
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
   aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
   crime-forms-end-to-end-tests: ministryofjustice/crime-forms-end-to-end-tests@volatile
@@ -109,10 +109,10 @@ commands:
           name: Run rubocop
           command: bundle exec rubocop
 
-  build-docker-image:
+  build-docker-image-for-scan:
     steps:
       - run:
-          name: Compile Docker Image
+          name: Build docker image for app
           command: |
               docker build \
                 --build-arg APP_BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
@@ -163,29 +163,45 @@ jobs:
       - run-tests
 
   scan-docker-image:
-    working_directory: ~/repo
     executor: test-executor
     steps:
-      - checkout:
-          path: ~/repo
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - build-docker-image
-      - snyk/scan:
+      - build-docker-image-for-scan
+      - snyk/install:
           token-variable: SNYK_TOKEN
-          docker-image-name: app
-          target-file: ./Dockerfile
-          organization: 'legal-aid-agency'
-          project: ministryofjustice/laa-crime-application-store
-          severity-threshold: "high"
-          fail-on-issues: true
-      - snyk/scan:
+      - run:
+          name: Run static code analysis
+          command: snyk code test --severity-threshold=high
+      - run:
+          name: Test open source dependencies
+          command: snyk test --all-projects --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor for open source vulnerabilities and license issues
+          command: snyk monitor --all-projects
+      - run:
+          name: Scan container image for vulnerabilities
+          command: snyk container test app --file=./Dockerfile --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor container image for vulnerabilities
+          command: snyk container monitor app
+
+  scan-metabase-docker-image:
+    executor: test-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - build-docker-image-for-scan
+      - snyk/install:
           token-variable: SNYK_TOKEN
-          docker-image-name: metabase/metabase:v0.49.13
-          organization: 'legal-aid-agency'
-          project: ministryofjustice/laa-crime-applications-metabase
-          severity-threshold: "high"
-          fail-on-issues: true
+      - run:
+          name: Scan container image for vulnerabilities
+          command: snyk container test metabase/metabase:v0.49.13 --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor container image for vulnerabilities
+          command: snyk container monitor metabase/metabase:v0.49.13
 
   build-and-push:
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
@@ -291,6 +307,11 @@ workflows:
             branches:
               ignore:
                 - main
+      - scan-metabase-docker-image:
+          filters:
+            branches:
+              ignore:
+                - main
 
   build-and-deploy-open-pr:
     jobs:
@@ -333,11 +354,17 @@ workflows:
             branches:
               only:
                 - main
+      - scan-metabase-docker-image:
+          filters:
+            branches:
+              only:
+                - main
       - build-and-push:
           requires:
             - lint-app
             - test-app
             - scan-docker-image
+            - scan-metabase-docker-image
       - e2e-test-main:
           context:
             - laa-non-standard-crime-claims-alerting


### PR DESCRIPTION
## Description of change
Change snyk docker scanning approach

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1529)

## Notes for reviewer
This implements all but the IaC scan. The reason for not implementing IaC scanning now is:
- IaC needs rendered terraform or k8s manifests to scan, not helm templates
- attempts to render the manifests and pass them to the `snyk IaC test` hit various problems to do with helm install on test-executor (overcome), requiring k8s login for rendering the manifest (requiring cloud-platform-executor) or snyk install on cloud-platform-executor, and it has not been possible to test whether a helm upgrade --dry-run output would work. Certainly a `helm template blah` command as suggested by snyk docs is insufficient in our case. Ideally the cloud-platform-executor would have snyk installed so we can render manifests and then, hopefully these can be scanned by `snyk iac test`
