### PR TITLE
Crm457 1713 - SPIKE Caseworker: Search and filter - required changes to datastore

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -3,6 +3,10 @@ class Search < ApplicationRecord
   belongs_to :submission, foreign_key: :application_id
   belongs_to :submission_version, foreign_key: :id, primary_key: :application_version_id
 
+  # NOTE: This works due to splitting the search query via weights, with ufn and laa_reference
+  # as weight A, then using simple reg-exp to determine which inputs should be queried on weight
+  # A, and then everything else being only weight B.
+  # This stops partial matches from being possible against the weight A values.
   def self.search(string)
     sub_strings = string.downcase.split(/\s+/).map do |str|
       if str =~ /\Alaa-/

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -13,7 +13,6 @@ class Search < ApplicationRecord
         clean_str = str.sub(/\Alaa-/, "laa")
         "#{clean_str}:A"
       elsif /\A\d+\/\d+\z/.match?(str) then "#{str}:A"
-      elsif str.blank? then nil
       else
         "#{str}:*B"
       end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -9,12 +9,13 @@ class Search < ApplicationRecord
   # This stops partial matches from being possible against the weight A values.
   def self.search(string)
     sub_strings = string.downcase.split(/\s+/).map do |str|
-      if str =~ /\Alaa-/
-        clean_str = str.sub(/\Alaa-/, 'laa')
+      if str.start_with?("laa-")
+        clean_str = str.sub(/\Alaa-/, "laa")
         "#{clean_str}:A"
-      elsif str =~ /\A\d+\/\d+\z/ then "#{str}:A"
+      elsif /\A\d+\/\d+\z/.match?(str) then "#{str}:A"
       elsif str.blank? then nil
-      else "#{str}:*B"
+      else
+        "#{str}:*B"
       end
     end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -4,7 +4,7 @@ class Search < ApplicationRecord
   belongs_to :submission_version, foreign_key: :id, primary_key: :application_version_id
 
   def self.search(string)
-    where("searches.search_fields @@ to_tsquery('simple', ?)", string).or(
+    where("searches.search_fields @@ to_tsquery('simple', ?)", string.sub(' ', ' & ')).or(
       where("LOWER(searches.ufn) = LOWER(?)", string),
     ).or(
       where("LOWER(searches.laa_reference) = LOWER(?)", string),

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -13,8 +13,9 @@ class Search < ApplicationRecord
         clean_str = str.sub(/\Alaa-/, "laa")
         "#{clean_str}:A"
       elsif /\A\d+\/\d+\z/.match?(str) then "#{str}:A"
+      elsif /\A\d+{6}\z/.match?(str) then "#{str}:*"
       else
-        "#{str}:*B"
+        "#{str.gsub("/", "-")}:*B"
       end
     end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -4,7 +4,7 @@ class Search < ApplicationRecord
   belongs_to :submission_version, foreign_key: :id, primary_key: :application_version_id
 
   def self.search(string)
-    where("searches.search_fields @@ to_tsquery('simple', ?)", string.sub(' ', ' & ')).or(
+    where("searches.search_fields @@ to_tsquery('simple', ?)", string.sub(" ", " & ")).or(
       where("LOWER(searches.ufn) = LOWER(?)", string),
     ).or(
       where("LOWER(searches.laa_reference) = LOWER(?)", string),

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,9 +5,9 @@ class Search < ApplicationRecord
 
   def self.search(string)
     where("searches.search_fields @@ to_tsquery('simple', ?)", string).or(
-      where("LOWER(searches.ufn) = LOWER(?)", string)
+      where("LOWER(searches.ufn) = LOWER(?)", string),
     ).or(
-      where("LOWER(searches.laa_reference) = LOWER(?)", string)
+      where("LOWER(searches.laa_reference) = LOWER(?)", string),
     )
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,13 @@
+class Search < ApplicationRecord
+  self.primary_key = :id
+  belongs_to :submission, foreign_key: :application_id
+  belongs_to :submission_version, foreign_key: :id, primary_key: :application_version_id
+
+  def self.search(string)
+    where("searches.search_fields @@ to_tsquery('simple', ?)", string).or(
+      where("LOWER(searches.ufn) = LOWER(?)", string)
+    ).or(
+      where("LOWER(searches.laa_reference) = LOWER(?)", string)
+    )
+  end
+end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -4,10 +4,16 @@ class Search < ApplicationRecord
   belongs_to :submission_version, foreign_key: :id, primary_key: :application_version_id
 
   def self.search(string)
-    where("searches.search_fields @@ to_tsquery('simple', ?)", string.sub(" ", " & ")).or(
-      where("LOWER(searches.ufn) = LOWER(?)", string),
-    ).or(
-      where("LOWER(searches.laa_reference) = LOWER(?)", string),
-    )
+    sub_strings = string.downcase.split(/\s+/).map do |str|
+      if str =~ /\Alaa-/
+        clean_str = str.sub(/\Alaa-/, 'laa')
+        "#{clean_str}:A"
+      elsif str =~ /\A\d+\/\d+\z/ then "#{str}:A"
+      elsif str.blank? then nil
+      else "#{str}:*B"
+      end
+    end
+
+    where("searches.search_fields @@ to_tsquery('simple', ?)", sub_strings.compact.join(" & "))
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -15,7 +15,7 @@ class Search < ApplicationRecord
       elsif /\A\d+\/\d+\z/.match?(str) then "#{str}:A"
       elsif /\A\d+{6}\z/.match?(str) then "#{str}:*"
       else
-        "#{str.gsub("/", "-")}:*B"
+        "#{str.tr('/', '-')}:*B"
       end
     end
 

--- a/db/migrate/20240703123137_create_searches.rb
+++ b/db/migrate/20240703123137_create_searches.rb
@@ -1,0 +1,5 @@
+class CreateSearches < ActiveRecord::Migration[7.1]
+  def change
+    # create_view :searches
+  end
+end

--- a/db/migrate/20240703161618_add_virtual_columns.rb
+++ b/db/migrate/20240703161618_add_virtual_columns.rb
@@ -1,6 +1,6 @@
 class AddVirtualColumns < ActiveRecord::Migration[7.1]
   def change
-    # NOTE: we remove the '-' from laa_reference as otehreise the to_query will break it
+    # NOTE: we remove the '-' from laa_reference as otherwise the to_query will break it
     # NOTE: we use weight:
     # * A - ufn and laa-reference
     # * B - all other fields

--- a/db/migrate/20240703161618_add_virtual_columns.rb
+++ b/db/migrate/20240703161618_add_virtual_columns.rb
@@ -1,35 +1,36 @@
 class AddVirtualColumns < ActiveRecord::Migration[7.1]
   def change
-    client_name_vetcor = <<~VECTOR
-      to_tsvector('english', application -> 'defendant' ->> 'first_name') || \
-      to_tsvector('english', application -> 'defendant' ->> 'last_name') || \
-      TO_TSVECTOR(jsonb_path_query_array(application,  '$.defendants[*].first_name')) || \
-      TO_TSVECTOR(jsonb_path_query_array(application, '$.defendants[*].last_name'))
+    search_vector = <<~VECTOR
+      TO_TSVECTOR('simple', application -> 'defendant' ->> 'first_name') || \
+      TO_TSVECTOR('simple', application -> 'defendant' ->> 'last_name') || \
+      TO_TSVECTOR('simple', jsonb_path_query_array(application,  '$.defendants[*].first_name')) || \
+      TO_TSVECTOR('simple', jsonb_path_query_array(application, '$.defendants[*].last_name')) || \
+      TO_TSVECTOR('simple', application -> 'firm_office' ->> 'name') || \
+      TO_TSVECTOR('simple', application ->> 'ufn') || \
+      TO_TSVECTOR('simple', application ->> 'laa_reference')
     VECTOR
 
     add_column(
       :application_version,
-      :client_name,
+      :search_fields,
       :virtual,
-      as: client_name_vetcor,
+      as: search_vector,
       type: :tsvector,
       stored: true
     )
+
+    # How the query works
+    # '$[*] ? (@.event_type == \"assignment\").primary_user_id'
+    # $[*]                               => search through each element of the array
+    # ? (@.event_type == \"assignment\") => filter to rows that have an event type of 'assignment'
+    # .primary_user_id                   => return the primary_user_id from the filtered rows
     add_column(
-      :application_version, :ufn, :virtual,
-      as: "(application ->> 'ufn')", type: :string, stored: true
+      :application,
+      :has_been_assigned_to,
+      :virtual,
+      as: "jsonb_path_query_array(events, '$[*] ? (@.event_type == \"assignment\").primary_user_id')",
+      type: :jsonb,
+      stored: true
     )
-    add_column(
-      :application_version, :firm_name, :virtual,
-      as: "(application -> 'firm_office' ->> 'name')", type: :string, stored: true
-    )
-    add_column(
-      :application_version, :laa_reference, :virtual,
-      as: "(application ->> 'laa_reference')", type: :string, stored: true
-    )
-    # add_column(
-    #   :application, :defendants, :virtual,
-    #   as: "json_array_elements(events)", type: :string, stored: true
-    # )
   end
 end

--- a/db/migrate/20240703161618_add_virtual_columns.rb
+++ b/db/migrate/20240703161618_add_virtual_columns.rb
@@ -1,0 +1,35 @@
+class AddVirtualColumns < ActiveRecord::Migration[7.1]
+  def change
+    client_name_vetcor = <<~VECTOR
+      to_tsvector('english', application -> 'defendant' ->> 'first_name') || \
+      to_tsvector('english', application -> 'defendant' ->> 'last_name') || \
+      TO_TSVECTOR(jsonb_path_query_array(application,  '$.defendants[*].first_name')) || \
+      TO_TSVECTOR(jsonb_path_query_array(application, '$.defendants[*].last_name'))
+    VECTOR
+
+    add_column(
+      :application_version,
+      :client_name,
+      :virtual,
+      as: client_name_vetcor,
+      type: :tsvector,
+      stored: true
+    )
+    add_column(
+      :application_version, :ufn, :virtual,
+      as: "(application ->> 'ufn')", type: :string, stored: true
+    )
+    add_column(
+      :application_version, :firm_name, :virtual,
+      as: "(application -> 'firm_office' ->> 'name')", type: :string, stored: true
+    )
+    add_column(
+      :application_version, :laa_reference, :virtual,
+      as: "(application ->> 'laa_reference')", type: :string, stored: true
+    )
+    # add_column(
+    #   :application, :defendants, :virtual,
+    #   as: "json_array_elements(events)", type: :string, stored: true
+    # )
+  end
+end

--- a/db/migrate/20240703183137_create_searches.rb
+++ b/db/migrate/20240703183137_create_searches.rb
@@ -1,5 +1,5 @@
 class CreateSearches < ActiveRecord::Migration[7.1]
   def change
-    # create_view :searches
+    create_view :searches
   end
 end

--- a/db/migrate/20240708131924_stupid_forward_slash.rb
+++ b/db/migrate/20240708131924_stupid_forward_slash.rb
@@ -1,0 +1,51 @@
+class StupidForwardSlash < ActiveRecord::Migration[7.1]
+  def up
+    new_search_vector = <<~VECTOR
+      SETWEIGHT(TO_TSVECTOR('simple', REPLACE(COALESCE(application -> 'defendant' ->> 'first_name', ''), '/', '-')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', REPLACE(COALESCE(application -> 'defendant' ->> 'last_name', ''), '/', '-')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', replace(jsonb_path_query_array(application,  '$.defendants[*].first_name')::text, '/', '-')::jsonb), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', replace(jsonb_path_query_array(application, '$.defendants[*].last_name')::text, '/', '-')::jsonb), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', REPLACE(COALESCE(application -> 'firm_office' ->> 'name', ''), '/', '-')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', COALESCE(application ->> 'ufn', '')), 'A') || \
+      SETWEIGHT(TO_TSVECTOR('simple', REPLACE(LOWER(COALESCE(application ->> 'laa_reference', '')), '-', '')), 'A')
+    VECTOR
+
+    drop_view :searches
+    remove_column(:application_version, :search_fields)
+    add_column(
+      :application_version,
+      :search_fields,
+      :virtual,
+      as: new_search_vector,
+      type: :tsvector,
+      stored: true
+    )
+    add_index(:application_version, :search_fields, using: 'gin')
+    create_view :searches
+  end
+
+  def down
+    old_search_vector = <<~VECTOR
+      SETWEIGHT(TO_TSVECTOR('simple', COALESCE(application -> 'defendant' ->> 'first_name', '')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', COALESCE(application -> 'defendant' ->> 'last_name', '')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', jsonb_path_query_array(application,  '$.defendants[*].first_name')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', jsonb_path_query_array(application, '$.defendants[*].last_name')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', COALESCE(application -> 'firm_office' ->> 'name', '')), 'B') || \
+      SETWEIGHT(TO_TSVECTOR('simple', COALESCE(application ->> 'ufn', '')), 'A') || \
+      SETWEIGHT(TO_TSVECTOR('simple', REPLACE(LOWER(COALESCE(application ->> 'laa_reference', '')), '-', '')), 'A')
+    VECTOR
+
+    drop_view :searches
+    remove_column(:application_version, :search_fields)
+    add_column(
+      :application_version,
+      :search_fields,
+      :virtual,
+      as: old_search_vector,
+      type: :tsvector,
+      stored: true
+    )
+    add_index(:application_version, :search_fields, using: 'gin')
+    create_view :searches
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_08_130210) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_183137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_130210) do
     t.datetime "updated_at", precision: nil
     t.jsonb "events"
     t.datetime "created_at", precision: nil
+    t.virtual "has_been_assigned_to", type: :jsonb, as: "jsonb_path_query_array(events, '$[*]?(@.\"event_type\" == \"assignment\").\"primary_user_id\"'::jsonpath)", stored: true
     t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null", validate: false
     t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null", validate: false
   end
@@ -33,6 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_130210) do
     t.jsonb "application", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.virtual "search_fields", type: :tsvector, as: "((((((to_tsvector('simple'::regconfig, ((application -> 'defendant'::text) ->> 'first_name'::text)) || to_tsvector('simple'::regconfig, ((application -> 'defendant'::text) ->> 'last_name'::text))) || to_tsvector('simple'::regconfig, jsonb_path_query_array(application, '$.\"defendants\"[*].\"first_name\"'::jsonpath))) || to_tsvector('simple'::regconfig, jsonb_path_query_array(application, '$.\"defendants\"[*].\"last_name\"'::jsonpath))) || to_tsvector('simple'::regconfig, ((application -> 'firm_office'::text) ->> 'name'::text))) || to_tsvector('simple'::regconfig, (application ->> 'ufn'::text))) || to_tsvector('simple'::regconfig, (application ->> 'laa_reference'::text)))", stored: true
   end
 
   create_table "subscriber", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -114,5 +116,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_130210) do
      FROM (all_events e
        JOIN application_version a ON (((a.application_id = e.id) AND (a.version = e.submission_version))))
     WHERE ((e.application_type = 'crm4'::text) AND (e.event_type = 'auto_decision'::text));
+  SQL
+  create_view "searches", sql_definition: <<-SQL
+      SELECT app_ver.id,
+      app_ver.application_id,
+      app_ver.search_fields,
+      app.has_been_assigned_to,
+      app.created_at AS date_submitted,
+      app.updated_at AS date_updated,
+      app.application_state AS status,
+      app.application_type AS submission_type,
+      app.application_risk AS risk
+     FROM (application app
+       JOIN application_version app_ver ON (((app.id = app_ver.application_id) AND (app.current_version = app_ver.version))));
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_183137) do
     t.jsonb "events"
     t.datetime "created_at", precision: nil
     t.virtual "has_been_assigned_to", type: :jsonb, as: "jsonb_path_query_array(events, '$[*]?(@.\"event_type\" == \"assignment\").\"primary_user_id\"'::jsonpath)", stored: true
-    t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null", validate: false
-    t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null", validate: false
+    t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null"
+    t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null"
   end
 
   create_table "application_version", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_183137) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_08_131924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_183137) do
     t.jsonb "application", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.virtual "search_fields", type: :tsvector, as: "((((((setweight(to_tsvector('simple'::regconfig, COALESCE(((application -> 'defendant'::text) ->> 'first_name'::text), ''::text)), 'B'::\"char\") || setweight(to_tsvector('simple'::regconfig, COALESCE(((application -> 'defendant'::text) ->> 'last_name'::text), ''::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, jsonb_path_query_array(application, '$.\"defendants\"[*].\"first_name\"'::jsonpath)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, jsonb_path_query_array(application, '$.\"defendants\"[*].\"last_name\"'::jsonpath)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE(((application -> 'firm_office'::text) ->> 'name'::text), ''::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((application ->> 'ufn'::text), ''::text)), 'A'::\"char\")) || setweight(to_tsvector('simple'::regconfig, replace(lower(COALESCE((application ->> 'laa_reference'::text), ''::text)), '-'::text, ''::text)), 'A'::\"char\"))", stored: true
+    t.virtual "search_fields", type: :tsvector, as: "((((((setweight(to_tsvector('simple'::regconfig, replace(COALESCE(((application -> 'defendant'::text) ->> 'first_name'::text), ''::text), '/'::text, '-'::text)), 'B'::\"char\") || setweight(to_tsvector('simple'::regconfig, replace(COALESCE(((application -> 'defendant'::text) ->> 'last_name'::text), ''::text), '/'::text, '-'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (replace((jsonb_path_query_array(application, '$.\"defendants\"[*].\"first_name\"'::jsonpath))::text, '/'::text, '-'::text))::jsonb), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (replace((jsonb_path_query_array(application, '$.\"defendants\"[*].\"last_name\"'::jsonpath))::text, '/'::text, '-'::text))::jsonb), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, replace(COALESCE(((application -> 'firm_office'::text) ->> 'name'::text), ''::text), '/'::text, '-'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((application ->> 'ufn'::text), ''::text)), 'A'::\"char\")) || setweight(to_tsvector('simple'::regconfig, replace(lower(COALESCE((application ->> 'laa_reference'::text), ''::text)), '-'::text, ''::text)), 'A'::\"char\"))", stored: true
     t.index ["search_fields"], name: "index_application_version_on_search_fields", using: :gin
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_131924) do
       (events_raw.event_json ->> 'event_type'::text) AS event_type,
       ((events_raw.event_json ->> 'created_at'::text))::timestamp without time zone AS event_at,
       (((events_raw.event_json ->> 'created_at'::text))::timestamp without time zone)::date AS event_on,
-      (events_raw.event_json ->> 'primary_user_id'::text) AS primary_user_id,
-      (events_raw.event_json ->> 'secondary_user_id'::text) AS secondary_user_id,
+      ((events_raw.event_json ->> 'primary_user_id'::text))::integer AS primary_user_id,
+      ((events_raw.event_json ->> 'secondary_user_id'::text))::integer AS secondary_user_id,
       (events_raw.event_json -> 'details'::text) AS details
      FROM events_raw;
   SQL

--- a/db/views/searches_v01.sql
+++ b/db/views/searches_v01.sql
@@ -1,7 +1,9 @@
 SELECT
-  app_ver.id,
-  app_ver.application_id,
+  app.id,
+  app_ver.id as application_version_id,
   app_ver.search_fields,
+  app_ver.ufn,
+  app_ver.laa_reference,
   app.has_been_assigned_to,
   app.created_at as date_submitted,
   app.updated_at as date_updated, -- events can happen in caseworker after this? should we be checking max event time as well???

--- a/db/views/searches_v01.sql
+++ b/db/views/searches_v01.sql
@@ -2,8 +2,6 @@ SELECT
   app.id,
   app_ver.id as application_version_id,
   app_ver.search_fields,
-  app_ver.ufn,
-  app_ver.laa_reference,
   app.has_been_assigned_to,
   app.created_at as date_submitted,
   app.updated_at as date_updated, -- events can happen in caseworker after this? should we be checking max event time as well???

--- a/db/views/searches_v01.sql
+++ b/db/views/searches_v01.sql
@@ -1,60 +1,12 @@
--- client name
--- firm name
--- UFN
--- LAA reference
-
-with assignments AS (
-  SELECT id,
-    json_agg(details ->> 'primary_user_id') as assigned_to,
-  FROM all_events
-  WHERE application_type = 'crm4' and event_type = 'assignment'
-  group by id
-),
-base as (
-  SELECT
-    app_ver.id,
-    app_ver.application_id,
-    app.created_at as date_submitted,
-    app.updated_at as date_updated, -- events can happen in caseworker after this? should we be checking max event time as well???
-    app.state as status,
-    app.application_type as submission_type,
-    app.risk as risk
-  FROM application AS app
-  JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
-),
-simple_search_fields AS (
-  SELECT
-    app_ver.id,
-    app_ver.application_id,
-    app_ver.application -> 'defendant' ->> 'first_name' || app_ver.application -> 'defendant' ->> 'last_name' as pa_client_name,
-    app_ver.application ->> 'ufn' as ufn,
-    app_ver.application -> 'firm_office' ->> 'name' as firm_name,
-    app_ver.application ->> 'laa_reference' as laa_reference,
-  FROM application AS app
-  JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
-),
-complex_search_fields as (
-  select subq.id, subq.application_id, json_agg(defendant ->> 'first_name' || ' ' || defendant ->> 'last_name') as nsm_client_names
-  from (
-    select
-      app_ver.id,
-      app_ver.application_id,
-      json_array_elements(app_ver.application -> 'defendants') as defendant
-    FROM application AS app
-    JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
-  ) subq
-  GROUP BY subq.id, subq.application_id
-)
-
-select
-  base.*,
-  assignments.assigned_to,
-  simple_search_fields.pa_client_name,
-  simple_search_fields.ufn,
-  simple_search_fields.firm_name,
-  simple_search_fields.laa_reference,
-  complex_search_fields.nsm_client_names
-from base
-join assignments on base.id = assignments.id
-join simple_search_fields on base.id = simple_search_fields.id
-join complex_search_fields on base.id = complex_search_fields.id
+SELECT
+  app_ver.id,
+  app_ver.application_id,
+  app_ver.search_fields,
+  app.has_been_assigned_to,
+  app.created_at as date_submitted,
+  app.updated_at as date_updated, -- events can happen in caseworker after this? should we be checking max event time as well???
+  app.application_state as status,
+  app.application_type as submission_type,
+  app.application_risk as risk
+FROM application AS app
+JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version

--- a/db/views/searches_v01.sql
+++ b/db/views/searches_v01.sql
@@ -1,0 +1,60 @@
+-- client name
+-- firm name
+-- UFN
+-- LAA reference
+
+with assignments AS (
+  SELECT id,
+    json_agg(details ->> 'primary_user_id') as assigned_to,
+  FROM all_events
+  WHERE application_type = 'crm4' and event_type = 'assignment'
+  group by id
+),
+base as (
+  SELECT
+    app_ver.id,
+    app_ver.application_id,
+    app.created_at as date_submitted,
+    app.updated_at as date_updated, -- events can happen in caseworker after this? should we be checking max event time as well???
+    app.state as status,
+    app.application_type as submission_type,
+    app.risk as risk
+  FROM application AS app
+  JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
+),
+simple_search_fields AS (
+  SELECT
+    app_ver.id,
+    app_ver.application_id,
+    app_ver.application -> 'defendant' ->> 'first_name' || app_ver.application -> 'defendant' ->> 'last_name' as pa_client_name,
+    app_ver.application ->> 'ufn' as ufn,
+    app_ver.application -> 'firm_office' ->> 'name' as firm_name,
+    app_ver.application ->> 'laa_reference' as laa_reference,
+  FROM application AS app
+  JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
+),
+complex_search_fields as (
+  select subq.id, subq.application_id, json_agg(defendant ->> 'first_name' || ' ' || defendant ->> 'last_name') as nsm_client_names
+  from (
+    select
+      app_ver.id,
+      app_ver.application_id,
+      json_array_elements(app_ver.application -> 'defendants') as defendant
+    FROM application AS app
+    JOIN application_version AS app_ver on app.id = app_ver.application_id and app.current_version = app_ver.version
+  ) subq
+  GROUP BY subq.id, subq.application_id
+)
+
+select
+  base.*,
+  assignments.assigned_to,
+  simple_search_fields.pa_client_name,
+  simple_search_fields.ufn,
+  simple_search_fields.firm_name,
+  simple_search_fields.laa_reference,
+  complex_search_fields.nsm_client_names
+from base
+join assignments on base.id = assignments.id
+join simple_search_fields on base.id = simple_search_fields.id
+join complex_search_fields on base.id = complex_search_fields.id

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -6,14 +6,14 @@ FactoryBot.define do
     court_type { "other" }
     firm_office do
       {
-        'account_number' => '1A123B',
-        'address_line_1' => '2 Laywer Suite',
-        'address_line_2' => nil,
-        'name' => firm_name,
-        'postcode' => 'CR0 1RE',
-        'previous_id' => nil,
-        'town' => 'Lawyer Town',
-        'vat_registered' => 'yes'
+        "account_number" => "1A123B",
+        "address_line_1" => "2 Laywer Suite",
+        "address_line_2" => nil,
+        "name" => firm_name,
+        "postcode" => "CR0 1RE",
+        "previous_id" => nil,
+        "town" => "Lawyer Town",
+        "vat_registered" => "yes",
       }
     end
 

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -4,9 +4,22 @@ FactoryBot.define do
     laa_reference { "LAA-123456" }
     service_type { "other" }
     court_type { "other" }
+    firm_office do
+      {
+        'account_number' => '1A123B',
+        'address_line_1' => '2 Laywer Suite',
+        'address_line_2' => nil,
+        'name' => firm_name,
+        'postcode' => 'CR0 1RE',
+        'previous_id' => nil,
+        'town' => 'Lawyer Town',
+        'vat_registered' => 'yes'
+      }
+    end
 
     transient do
       defendant_name { nil }
+      firm_name { nil }
       first_name { defendant_name.present? ? defendant_name.split.first : "Joe" }
       last_name { defendant_name.present? ? defendant_name.split(" ", 2).last : "Bloggs" }
     end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     transient do
       defendant_name { nil }
       first_name { defendant_name.present? ? defendant_name.split.first : "Joe" }
-      last_name { defendant_name.present? ? defendant_name.split.first : "Bloggs" }
+      last_name { defendant_name.present? ? defendant_name.split(' ', 2).last : "Bloggs" }
     end
 
     trait :pa do

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :application, class: Hash do
+    initialize_with { attributes }
+    laa_reference { "LAA-123456" }
+    service_type { "other" }
+    court_type { "other" }
+  end
+
+  trait :pa do
+    defendant {
+      {first_name: 'Joe', last_name: 'Bloggs'}
+    }
+  end
+
+  trait :nsm do
+    defendants {
+      [
+        {
+          first_name => 'Joe',
+          last_name => 'Bloggs'
+        }
+      ]
+    }
+  end
+end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -7,19 +7,19 @@ FactoryBot.define do
   end
 
   trait :pa do
-    defendant {
-      {first_name: 'Joe', last_name: 'Bloggs'}
-    }
+    defendant do
+      { first_name: "Joe", last_name: "Bloggs" }
+    end
   end
 
   trait :nsm do
-    defendants {
+    defendants do
       [
         {
-          first_name => 'Joe',
-          last_name => 'Bloggs'
-        }
+          first_name => "Joe",
+          last_name => "Bloggs",
+        },
       ]
-    }
+    end
   end
 end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     laa_reference { "LAA-123456" }
     service_type { "other" }
     court_type { "other" }
+    ufn { "010124/001" }
     firm_office do
       {
         "account_number" => "1A123B",

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -4,22 +4,23 @@ FactoryBot.define do
     laa_reference { "LAA-123456" }
     service_type { "other" }
     court_type { "other" }
-  end
 
-  trait :pa do
-    defendant do
-      { first_name: "Joe", last_name: "Bloggs" }
+    transient do
+      defendant_name { nil }
+      first_name { defendant_name.present? ? defendant_name.split(' ').first : "Joe" }
+      last_name { defendant_name.present? ? defendant_name.split(' ').first : "Bloggs" }
     end
-  end
 
-  trait :nsm do
-    defendants do
-      [
-        {
-          first_name => "Joe",
-          last_name => "Bloggs",
-        },
-      ]
+    trait :pa do
+      defendant do
+        { first_name:, last_name: }
+      end
+    end
+
+    trait :nsm do
+      defendants do
+        [{ first_name:, last_name: }]
+      end
     end
   end
 end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     transient do
       defendant_name { nil }
       first_name { defendant_name.present? ? defendant_name.split.first : "Joe" }
-      last_name { defendant_name.present? ? defendant_name.split(' ', 2).last : "Bloggs" }
+      last_name { defendant_name.present? ? defendant_name.split(" ", 2).last : "Bloggs" }
     end
 
     trait :pa do

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
 
     transient do
       defendant_name { nil }
-      first_name { defendant_name.present? ? defendant_name.split(' ').first : "Joe" }
-      last_name { defendant_name.present? ? defendant_name.split(' ').first : "Bloggs" }
+      first_name { defendant_name.present? ? defendant_name.split.first : "Joe" }
+      last_name { defendant_name.present? ? defendant_name.split.first : "Bloggs" }
     end
 
     trait :pa do

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -2,13 +2,14 @@ FactoryBot.define do
   factory :submission_version do
     json_schema_version { 1 }
     version { 1 }
-    application factory: :application_data, strategy: :build
+    application factory: :application, strategy: :build
   end
 
-  factory :application_data, class: Hash do
-    initialize_with { attributes }
-    laa_reference { "LAA-123456" }
-    service_type { "other" }
-    court_type { "other" }
+  trait :with_pa_application do
+    application factory: %i[application pa], strategy: :build
+  end
+
+  trait :with_nsm_application do
+    application factory: %i[application pa], strategy: :build
   end
 end

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -2,14 +2,18 @@ FactoryBot.define do
   factory :submission_version do
     json_schema_version { 1 }
     version { 1 }
-    application factory: :application, strategy: :build
-  end
 
-  trait :with_pa_application do
-    application factory: %i[application pa], strategy: :build
-  end
+    transient do
+      defendant_name { nil }
+    end
+    application { build(:application, defendant_name:) }
 
-  trait :with_nsm_application do
-    application factory: %i[application pa], strategy: :build
+    trait :with_pa_application do
+      application { build(:application, :pa, defendant_name:) }
+    end
+
+    trait :with_nsm_application do
+      application { build(:application, :nsm, defendant_name:) }
+    end
   end
 end

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -5,15 +5,16 @@ FactoryBot.define do
 
     transient do
       defendant_name { nil }
+      firm_name { nil }
     end
-    application { build(:application, defendant_name:) }
+    application { build(:application, defendant_name:, firm_name:) }
 
     trait :with_pa_application do
-      application { build(:application, :pa, defendant_name:) }
+      application { build(:application, :pa, defendant_name:, firm_name:) }
     end
 
     trait :with_nsm_application do
-      application { build(:application, :nsm, defendant_name:) }
+      application { build(:application, :nsm, defendant_name:, firm_name:) }
     end
   end
 end

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -6,15 +6,16 @@ FactoryBot.define do
     transient do
       defendant_name { nil }
       firm_name { nil }
+      ufn { nil }
     end
-    application { build(:application, defendant_name:, firm_name:) }
+    application { build(:application, defendant_name:, firm_name:, ufn: ufn || "010124/001") }
 
     trait :with_pa_application do
-      application { build(:application, :pa, defendant_name:, firm_name:) }
+      application { build(:application, :pa, defendant_name:, firm_name:, ufn: ufn || "010124/001") }
     end
 
     trait :with_nsm_application do
-      application { build(:application, :nsm, defendant_name:, firm_name:) }
+      application { build(:application, :nsm, defendant_name:, firm_name:, ufn: ufn || "010124/001") }
     end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -14,20 +14,22 @@ FactoryBot.define do
     application_type { "crm4" }
     current_version { 1 }
     events { [] }
-    after(:build) do |submission, _a|
-      create(:submission_version, submission:)
-    end
-  end
 
-  trait :with_pa_version do
-    after(:build) do |submission, _a|
-      create(:submission_version, :with_pa_application, submission:)
+    transient do
+      defendant_name { nil }
+      build_scope { [] }
     end
-  end
 
-  trait :with_nsm_version do
-    after(:build) do |submission, _a|
-      create(:submission_version, :with_nsm_application, submission:)
+    after(:build) do |submission, a|
+      create(:submission_version, *(a.build_scope), submission: submission, defendant_name: a.defendant_name)
+    end
+
+    trait :with_pa_version do
+      build_scope { [:with_pa_application] }
+    end
+
+    trait :with_nsm_version do
+      build_scope { [:with_nsm_application] }
     end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -24,9 +24,10 @@ FactoryBot.define do
     after(:build) do |submission, a|
       create(
         :submission_version, *a.build_scope,
-        submission: submission,
+        submission:,
         defendant_name: a.defendant_name,
-        firm_name: a.firm_name)
+        firm_name: a.firm_name
+      )
     end
 
     trait :with_pa_version do

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     after(:build) do |submission, a|
-      create(:submission_version, *(a.build_scope), submission: submission, defendant_name: a.defendant_name)
+      create(:submission_version, *a.build_scope, submission:, defendant_name: a.defendant_name)
     end
 
     trait :with_pa_version do

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     transient do
       defendant_name { nil }
       firm_name { nil }
+      ufn { nil }
       build_scope { [] }
     end
 
@@ -26,7 +27,8 @@ FactoryBot.define do
         :submission_version, *a.build_scope,
         submission:,
         defendant_name: a.defendant_name,
-        firm_name: a.firm_name
+        firm_name: a.firm_name,
+        ufn: a.ufn
       )
     end
 

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -17,11 +17,16 @@ FactoryBot.define do
 
     transient do
       defendant_name { nil }
+      firm_name { nil }
       build_scope { [] }
     end
 
     after(:build) do |submission, a|
-      create(:submission_version, *a.build_scope, submission:, defendant_name: a.defendant_name)
+      create(
+        :submission_version, *a.build_scope,
+        submission: submission,
+        defendant_name: a.defendant_name,
+        firm_name: a.firm_name)
     end
 
     trait :with_pa_version do

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     application_type { "crm4" }
     current_version { 1 }
     events { [] }
-    after(:create) do |submission, _a|
+    after(:build) do |submission, _a|
       create(:submission_version, submission:)
     end
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -18,4 +18,16 @@ FactoryBot.define do
       create(:submission_version, submission:)
     end
   end
+
+  trait :with_pa_version do
+    after(:build) do |submission, _a|
+      create(:submission_version, :with_pa_application, submission:)
+    end
+  end
+
+  trait :with_nsm_version do
+    after(:build) do |submission, _a|
+      create(:submission_version, :with_nsm_application, submission:)
+    end
+  end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -157,8 +157,7 @@ RSpec.describe Search do
           expect(search).to eq([prepare.id])
         end
 
-        # TBC: not surrently working due to `/`
-        context 'with additional partial name matches' do
+        context "with additional partial name matches" do
           let(:prepare) do
             [
               build(:submission, :with_pa_version, defendant_name: "Jason/Jim Read").tap(&:save),
@@ -168,12 +167,14 @@ RSpec.describe Search do
             ]
           end
 
-          xit "matches all records on each part of name" do
+          it "matches all records on each part of name" do
+            skip "TBC: not surrently working due to `/`"
+
             expect(search).to eq(prepare[0..2].map(&:id))
           end
         end
 
-        context "search on first part of first name only" do
+        context "when searching on the first part of first name only" do
           let(:query) { "Jason" }
 
           it "returns the record" do
@@ -181,11 +182,12 @@ RSpec.describe Search do
           end
         end
 
-        # TBC: not surrently working due to `/`
-        context "search on last part of first name only" do
+        context "when searching on the last part of first name only" do
           let(:query) { "Jim" }
 
-          xit "returns the record" do
+          it "returns the record" do
+            skip "TBC: not surrently working due to `/`"
+
             expect(search).to eq([prepare.id])
           end
         end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Search do
       end
     end
 
-    context "when search text is not LAA reference" do
+    context "when search text is LAA reference does not match any records" do
       let(:query) { "LAA-121212" }
 
       it "returns the record" do
@@ -45,6 +45,37 @@ RSpec.describe Search do
 
       it "returns the record" do
         expect(subject).to be_empty
+      end
+    end
+
+    context "when search text is full defendant name" do
+      let(:query) { "joe bloggs" }
+
+      context "application is prior authority" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(subject).to eq([prepare.id])
+        end
+      end
+
+      context "application is non-standard magistrate" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(subject).to eq([prepare.id])
+        end
+      end
+
+      context "when search text is partial defendant name" do
+        let(:query) { "joe" }
+        context "application is prior authority" do
+          let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+          it "returns the record" do
+            expect(subject).to eq([prepare.id])
+          end
+        end
       end
     end
   end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,39 +1,41 @@
 require "rails_helper"
 
 RSpec.describe Search do
-  describe '#search_laa_reference' do
-    before { prepare }
+  describe "#search_laa_reference" do
     subject { described_class.search(query).pluck(:id) }
+
+    before { prepare }
+
     let(:prepare) { build(:submission).tap(&:save) }
 
-    context 'when search text is LAA reference' do
+    context "when search text is LAA reference" do
       let(:query) { "LAA-123456" }
 
-      it 'returns the record' do
+      it "returns the record" do
         expect(subject).to eq([prepare.id])
       end
     end
 
-    context 'when search text is not LAA reference' do
+    context "when search text is not LAA reference" do
       let(:query) { "LAA-121212" }
 
-      it 'returns the record' do
+      it "returns the record" do
         expect(subject).to be_empty
       end
     end
 
-    context 'when search text is full number part of LAA reference' do
+    context "when search text is full number part of LAA reference" do
       let(:query) { "123456" }
 
-      it 'returns the record' do
+      it "returns the record" do
         expect(subject).to be_empty
       end
     end
 
-    context 'when search text is partial number part of LAA reference' do
+    context "when search text is partial number part of LAA reference" do
       let(:query) { "345" }
 
-      it 'returns the record' do
+      it "returns the record" do
         expect(subject).to be_empty
       end
     end
@@ -41,8 +43,7 @@ RSpec.describe Search do
     context "when search text is 'laa'" do
       let(:query) { "laa" }
 
-      it 'returns the record' do
-        debugger
+      it "returns the record" do
         expect(subject).to be_empty
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Search do
   describe "#search_laa_reference" do
-    search { described_class.search(query).pluck(:id) }
+    let(:search) { described_class.search(query).pluck(:id) }
 
     before { prepare }
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -307,8 +307,8 @@ RSpec.describe Search do
         context "when it also matches a firm name" do
           let(:prepare) do
             [
-              build(:submission, ufn: '010123/002', firm_name: "party 010124").tap(&:save),
-              build(:submission, firm_name: "Wonder-1984").tap(&:save)
+              build(:submission, ufn: "010123/002", firm_name: "party 010124").tap(&:save),
+              build(:submission, firm_name: "Wonder-1984").tap(&:save),
             ]
           end
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -146,5 +146,58 @@ RSpec.describe Search do
         end
       end
     end
+
+    context "when user name is Jason/Jim" do
+      let(:query) { "Jason/Jim" }
+
+      context "with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version, defendant_name: "Jason/Jim Read").tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+
+        # TBC: not surrently working due to `/`
+        context 'with additional partial name matches' do
+          let(:prepare) do
+            [
+              build(:submission, :with_pa_version, defendant_name: "Jason/Jim Read").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "Jason Write").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "Jim Type").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "Jack Burns").tap(&:save),
+            ]
+          end
+
+          xit "matches all records on each part of name" do
+            expect(search).to eq(prepare[0..2].map(&:id))
+          end
+        end
+
+        context "search on first part of first name only" do
+          let(:query) { "Jason" }
+
+          it "returns the record" do
+            expect(search).to eq([prepare.id])
+          end
+        end
+
+        # TBC: not surrently working due to `/`
+        context "search on last part of first name only" do
+          let(:query) { "Jim" }
+
+          xit "returns the record" do
+            expect(search).to eq([prepare.id])
+          end
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version, defendant_name: "Jason/Jim Read").tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
   end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -67,6 +67,46 @@ RSpec.describe Search do
       end
     end
 
+    context "when partial match on part of defendant name" do
+      let(:query) { "joe blog" }
+
+      context "with with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
+    context "when it does not match all parts of defendant name" do
+      let(:query) { "bob bloggs" }
+
+      context "with with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to be_empty
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to be_empty
+        end
+      end
+    end
+
     context "when search text is partial defendant name" do
       let(:query) { "joe" }
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -167,10 +167,8 @@ RSpec.describe Search do
             ]
           end
 
-          it "matches all records on each part of name" do
-            skip "TBC: not surrently working due to `/`"
-
-            expect(search).to eq(prepare[0..2].map(&:id))
+          it "only matches when both name parts are present" do
+            expect(search).to eq([prepare[0].id])
           end
         end
 
@@ -195,6 +193,57 @@ RSpec.describe Search do
 
       context "with non-standard magistrate application" do
         let(:prepare) { build(:submission, :with_nsm_version, defendant_name: "Jason/Jim Read").tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
+    context "when user name is Burden-Hall" do
+      let(:query) { "Burden-Hall" }
+
+      context "with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version, defendant_name: "Jack Burden-Hall").tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+
+        context "with additional partial name matches" do
+          let(:prepare) do
+            [
+              build(:submission, :with_pa_version, defendant_name: "Jack Burden-Hall").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "Jim Burden").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "James Hall").tap(&:save),
+              build(:submission, :with_pa_version, defendant_name: "jack Ball").tap(&:save),
+            ]
+          end
+
+          it "only matches when both name parts are present" do
+            expect(search).to eq([prepare[0].id])
+          end
+        end
+
+        context "when searching on the first part of first name only" do
+          let(:query) { "Burden" }
+
+          it "returns the record" do
+            expect(search).to eq([prepare.id])
+          end
+        end
+
+        context "when searching on the last part of first name only" do
+          let(:query) { "Hall" }
+
+          it "returns the record" do
+            expect(search).to eq([prepare.id])
+          end
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version, defendant_name: "Jack Burden-Hall").tap(&:save) }
 
         it "returns the record" do
           expect(search).to eq([prepare.id])

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Search do
   describe "#search_laa_reference" do
-    subject { described_class.search(query).pluck(:id) }
+    search { described_class.search(query).pluck(:id) }
 
     before { prepare }
 
@@ -12,7 +12,7 @@ RSpec.describe Search do
       let(:query) { "LAA-123456" }
 
       it "returns the record" do
-        expect(subject).to eq([prepare.id])
+        expect(search).to eq([prepare.id])
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Search do
       let(:query) { "LAA-121212" }
 
       it "returns the record" do
-        expect(subject).to be_empty
+        expect(search).to be_empty
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Search do
       let(:query) { "123456" }
 
       it "returns the record" do
-        expect(subject).to be_empty
+        expect(search).to be_empty
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Search do
       let(:query) { "345" }
 
       it "returns the record" do
-        expect(subject).to be_empty
+        expect(search).to be_empty
       end
     end
 
@@ -44,38 +44,46 @@ RSpec.describe Search do
       let(:query) { "laa" }
 
       it "returns the record" do
-        expect(subject).to be_empty
+        expect(search).to be_empty
       end
     end
 
     context "when search text is full defendant name" do
       let(:query) { "joe bloggs" }
 
-      context "application is prior authority" do
+      context "with with prior authority application" do
         let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
 
         it "returns the record" do
-          expect(subject).to eq([prepare.id])
+          expect(search).to eq([prepare.id])
         end
       end
 
-      context "application is non-standard magistrate" do
+      context "with non-standard magistrate application" do
         let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
 
         it "returns the record" do
-          expect(subject).to eq([prepare.id])
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
+    context "when search text is partial defendant name" do
+      let(:query) { "joe" }
+
+      context "with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
         end
       end
 
-      context "when search text is partial defendant name" do
-        let(:query) { "joe" }
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
 
-        context "application is prior authority" do
-          let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
-
-          it "returns the record" do
-            expect(subject).to eq([prepare.id])
-          end
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
         end
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -293,5 +293,21 @@ RSpec.describe Search do
         end
       end
     end
+
+    context "when matching on UFN" do
+      let(:query) { "010124/001" }
+
+      it "returns the record" do
+        expect(search).to eq([prepare.id])
+      end
+
+      context "when only first part of the ufn" do
+        let(:query) { "010124" }
+
+        it "does not returns the record" do
+          expect(search).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -67,6 +67,26 @@ RSpec.describe Search do
       end
     end
 
+    context "when search text is laa-reference and full defendant name" do
+      let(:query) { "LAA-123456 joe bloggs" }
+
+      context "with with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
     context "when partial match on part of defendant name" do
       let(:query) { "joe blog" }
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Search do
+  describe '#search_laa_reference' do
+    before { prepare }
+    subject { described_class.search(query).pluck(:id) }
+    let(:prepare) { build(:submission).tap(&:save) }
+
+    context 'when search text is LAA reference' do
+      let(:query) { "LAA-123456" }
+
+      it 'returns the record' do
+        expect(subject).to eq([prepare.id])
+      end
+    end
+
+    context 'when search text is not LAA reference' do
+      let(:query) { "LAA-121212" }
+
+      it 'returns the record' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when search text is full number part of LAA reference' do
+      let(:query) { "123456" }
+
+      it 'returns the record' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when search text is partial number part of LAA reference' do
+      let(:query) { "345" }
+
+      it 'returns the record' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when search text is 'laa'" do
+      let(:query) { "laa" }
+
+      it 'returns the record' do
+        debugger
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Search do
       end
     end
 
-    context "when user name is Burden-Hall" do
+    context "when user last name is Burden-Hall" do
       let(:query) { "Burden-Hall" }
 
       context "with prior authority application" do
@@ -225,7 +225,7 @@ RSpec.describe Search do
           end
         end
 
-        context "when searching on the first part of first name only" do
+        context "when searching on the first part of last name only" do
           let(:query) { "Burden" }
 
           it "returns the record" do
@@ -233,7 +233,7 @@ RSpec.describe Search do
           end
         end
 
-        context "when searching on the last part of first name only" do
+        context "when searching on the last part of last name only" do
           let(:query) { "Hall" }
 
           it "returns the record" do
@@ -246,6 +246,49 @@ RSpec.describe Search do
         let(:prepare) { build(:submission, :with_nsm_version, defendant_name: "Jack Burden-Hall").tap(&:save) }
 
         it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
+    context "when firm name is Wonder-1984" do
+      let(:query) { "Wonder-1984" }
+
+      let(:prepare) { build(:submission, firm_name: "Wonder-1984").tap(&:save) }
+
+      it "returns the record" do
+        expect(search).to eq([prepare.id])
+      end
+
+      context "with additional partial name matches" do
+        let(:prepare) do
+          [
+            build(:submission, firm_name: "Wonder-1984").tap(&:save),
+            build(:submission, firm_name: "Wonder").tap(&:save),
+            build(:submission, firm_name: "Hope-1984").tap(&:save),
+            build(:submission, firm_name: "jack Ball").tap(&:save),
+          ]
+        end
+
+        it "only matches when both name parts are present" do
+          expect(search).to eq([prepare[0].id])
+        end
+      end
+
+      context "when searching on the first part of firm name only" do
+        let(:query) { "Wonder" }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+
+      context "when searching on the last part of firm name only" do
+        let(:query) { "1984" }
+
+        it "returns the record" do
+          skip "does not match as expects `-1984`"
+
           expect(search).to eq([prepare.id])
         end
       end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -184,8 +184,6 @@ RSpec.describe Search do
           let(:query) { "Jim" }
 
           it "returns the record" do
-            skip "TBC: not surrently working due to `/`"
-
             expect(search).to eq([prepare.id])
           end
         end
@@ -286,10 +284,8 @@ RSpec.describe Search do
       context "when searching on the last part of firm name only" do
         let(:query) { "1984" }
 
-        it "returns the record" do
-          skip "does not match as expects `-1984`"
-
-          expect(search).to eq([prepare.id])
+        it "does not match as thinks it needs `-1984`" do
+          expect(search).to be_empty
         end
       end
     end
@@ -304,8 +300,21 @@ RSpec.describe Search do
       context "when only first part of the ufn" do
         let(:query) { "010124" }
 
-        it "does not returns the record" do
-          expect(search).to be_empty
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+
+        context "when it also matches a firm name" do
+          let(:prepare) do
+            [
+              build(:submission, ufn: '010123/002', firm_name: "party 010124").tap(&:save),
+              build(:submission, firm_name: "Wonder-1984").tap(&:save)
+            ]
+          end
+
+          it "returns the both records" do
+            expect(search).to eq(prepare.map(&:id))
+          end
         end
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Search do
 
       context "when search text is partial defendant name" do
         let(:query) { "joe" }
+
         context "application is prior authority" do
           let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -3,10 +3,9 @@ require "rails_helper"
 RSpec.describe Search do
   describe "#search_laa_reference" do
     let(:search) { described_class.search(query).pluck(:id) }
+    let(:prepare) { build(:submission).tap(&:save) }
 
     before { prepare }
-
-    let(:prepare) { build(:submission).tap(&:save) }
 
     context "when search text is LAA reference" do
       let(:query) { "LAA-123456" }


### PR DESCRIPTION
## Description of change

[SPIKE Caseworker: Search and filter - required changes to datastore](https://dsdmoj.atlassian.net/browse/CRM457-1713)

## Notes for reviewer

- Searches table uses virtual fields to collate search keywords for a given application
- UFN and LAA Reference are special cases as the tsvector functions consider a dash followed by a number a negative number and a slash as an escape so these are searched via the original fields

## Further notes

* we are using weights to split how searching works. 
  - Items with a weight of A require a full match
  - items with a weight of B match the start of string only
* using regexp to remove `-` character from LAA reference to simplify matching
* two know edgecases that don't match when maybe the should:
  - names with a dash followed by a number ie. `Palace Court-1` these will match on `palace`, `court`, `palace-court`, `palace-court-1` but not `1`
  - names with a forward slash i.e. `James/Jim` will match on `James`, `James\Jim` but not `Jim`