### PR TITLE
CRM457-1726: Do not error out if caseworker submits late and redundant event payload

### DIFF
--- a/app/controllers/V1/events_controller.rb
+++ b/app/controllers/V1/events_controller.rb
@@ -1,8 +1,9 @@
 module V1
   class EventsController < ApplicationController
     def create
-      Submissions::UpdateService.add_events(current_submission, params, save: true)
-      head :created
+      Submissions::EventCreationService.call(current_submission, params)
+      current_submission.save!
+      head(:created)
     end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::API
   end
 
   def authorize!
-    allowed = AuthorizationService.call(
+    auth_result = AuthorizationService.call(
       @current_client_role,
       controller_name,
       action_name,
@@ -20,7 +20,12 @@ class ApplicationController < ActionController::API
       authorization_object,
     )
 
-    head(:forbidden) unless allowed
+    case auth_result
+    when :forbidden
+      head(:forbidden)
+    when :no_op
+      head(:no_content)
+    end
   end
 
   def authorization_object

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -49,6 +49,12 @@ module Authorization
       ],
     }.freeze
 
+    NO_OPS = {
+      events: {
+        create: ->(object, params) { (params[:events].pluck(:id) - (object.events || []).pluck("id")).empty? },
+      },
+    }.freeze
+
     def self.state_pair_allowed?(object, params, pairs)
       pairs.any? do |pair|
         object.application_state.in?(pair[:pre]) && params[:application_state].in?(pair[:post])

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -1,11 +1,15 @@
 class AuthorizationService
   def self.call(subject, category, verb, params, object)
+    return :no_op if Authorization::Rules::NO_OPS.dig(category.to_sym, verb.to_sym)&.call(object, params)
+
     rule = Authorization::Rules::PERMISSIONS.dig(subject, category.to_sym, verb.to_sym)
 
-    if rule.respond_to?(:call)
-      rule.call(object, params)
-    else
-      rule
-    end
+    permitted = if rule.respond_to?(:call)
+                  rule.call(object, params)
+                else
+                  rule
+                end
+
+    permitted ? :allowed : :forbidden
   end
 end

--- a/app/services/submissions/event_creation_service.rb
+++ b/app/services/submissions/event_creation_service.rb
@@ -1,0 +1,17 @@
+module Submissions
+  class EventCreationService
+    class << self
+      def call(submission, params)
+        submission.events ||= []
+        params[:events]&.each do |event|
+          next if submission.events.any? { _1["id"] == event["id"] }
+
+          event["submission_version"] ||= submission.current_version
+          event["created_at"] ||= Time.zone.now
+          event["updated_at"] ||= event["created_at"]
+          submission.events << event.as_json
+        end
+      end
+    end
+  end
+end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -11,18 +11,8 @@ module Submissions
         NotificationService.call(params[:id], role)
       end
 
-      def add_events(submission, params, save: false)
-        submission.events ||= []
-        params[:events]&.each do |event|
-          next if submission.events.any? { _1["id"] == event["id"] }
-
-          event["submission_version"] ||= submission.current_version
-          event["created_at"] ||= Time.zone.now
-          event["updated_at"] ||= event["created_at"]
-
-          submission.events << event.as_json
-        end
-        save && submission.save!
+      def add_events(submission, params)
+        EventCreationService.call(submission, params)
       end
 
       def add_new_version(submission, params)

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -71,5 +71,33 @@ RSpec.describe "Authorization" do
         expect(response).to have_http_status :forbidden
       end
     end
+
+    context "when client is making a change that would have no impact" do
+      let(:role) { "Caseworker" }
+      let(:params) { { events: [{ id: "ABC" }] } }
+      let(:submission) { create(:submission, application_state: state, events: [{ id: "ABC" }]) }
+
+      before do
+        post "/v1/submissions/#{submission.id}/events",
+             headers: { "Authorization" => "Bearer ABC" },
+             params:
+      end
+
+      context "when the type of operation would be forbidden" do
+        let(:state) { "granted" }
+
+        it "returns a 204 status" do
+          expect(response).to have_http_status :no_content
+        end
+      end
+
+      context "when the type of operation would be allowed" do
+        let(:state) { "submitted" }
+
+        it "still returns a 204 status" do
+          expect(response).to have_http_status :no_content
+        end
+      end
+    end
   end
 end

--- a/spec/requests/create_events_spec.rb
+++ b/spec/requests/create_events_spec.rb
@@ -35,17 +35,20 @@ RSpec.describe "Create events" do
         events: [
           {
             id: "A",
-            details: "history",
+            details: "rewritten history",
+          },
+          {
+            id: "B",
+            details: "something else",
           },
         ],
       }
       expect(response).to have_http_status :created
-      expect(submission.reload.events).to match([
-        {
-          "id" => "A",
-          "details" => "actual history",
-        },
-      ])
+      expect(submission.reload.events.count).to eq 2
+      expect(submission.events.find { _1["id"] == "A" }).to match(
+        "id" => "A",
+        "details" => "actual history",
+      )
     end
 
     it "does not increament the version" do


### PR DESCRIPTION
## Description of change
If request would not actually modify state, short-circuit with 204

Also make services a bit more modular so it's clearer what logic is running in what circumstances

This is an alternative approach to solve the same problem as https://github.com/ministryofjustice/laa-assess-crime-forms/pull/601. Basically if the caseworker app is late to the party trying to tell the app store about an event it already knows about, we don't want errors raised.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1726)
