### PR TITLE
Crm457 1638 fix autogrant view tests

### DIFF
--- a/spec/factories/translation.rb
+++ b/spec/factories/translation.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :translation do
+    key { "law_sol" }
+    translation { "Law Soliciting" }
+    translation_type { "service" }
+  end
+end

--- a/spec/postgres_views/autogrant_events_spec.rb
+++ b/spec/postgres_views/autogrant_events_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "autogrant_events" do
   let(:today) { Time.zone.now }
 
   before do
-    create(:translation, key: "ae_consultant", translation:"A&E consultant", translation_type: "service" )
+    create(:translation, key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
   end
 
   it "returns no records when no autogranted applications exist" do

--- a/spec/postgres_views/autogrant_events_spec.rb
+++ b/spec/postgres_views/autogrant_events_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "autogrant_events" do
   let(:today) { Time.zone.now }
 
   before do
-    create(:translation, key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
+    build(:translation, key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
   end
 
   it "returns no records when no autogranted applications exist" do

--- a/spec/postgres_views/autogrant_events_spec.rb
+++ b/spec/postgres_views/autogrant_events_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "autogrant_events" do
 
   let(:today) { Time.zone.now }
 
+  before do
+    create(:translation, key: "ae_consultant", translation:"A&E consultant", translation_type: "service" )
+  end
+
   it "returns no records when no autogranted applications exist" do
     create(
       :submission,


### PR DESCRIPTION
## Description of change

[Analytics Dashboard: Autogrant](https://dsdmoj.atlassian.net/browse/CRM457-1638)

## Notes for reviewer
Adds factory for translations and loads translation needed for tests as factory instead of relying on it being in the table in case a developer doesn't have the data in their test db (this can happen when the db already exists when db:prepare is run)