### PR TITLE
Use find or create by

### DIFF
--- a/spec/postgres_views/autogrant_events_spec.rb
+++ b/spec/postgres_views/autogrant_events_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "autogrant_events" do
   let(:today) { Time.zone.now }
 
   before do
-    build(:translation, key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
+    Translation.find_or_create_by(key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
   end
 
   it "returns no records when no autogranted applications exist" do


### PR DESCRIPTION
## Description of change
Use find_or_create_by to avoid issue of local setup not having seeds, but it they do standard factory create will error out on primary key uniqueness issues.
