### PR TITLE
CRM457-1747: Task to adjust status

### DIFF
--- a/lib/tasks/adjust_status.rake
+++ b/lib/tasks/adjust_status.rake
@@ -1,0 +1,14 @@
+
+namespace :adjust do
+  desc "Change the status of an application"
+  task :status, [:submission_id, :status, :role_to_notify] => :environment do |_, args|
+    submission = Submission.find(args.submission_id)
+    submission.update!(application_state: args.status)
+
+    next if args.role_to_notify.blank?
+
+    Subscriber.where(subscriber_type: args.role_to_notify).find_each do |subscriber|
+      NotifySubscriber.new.perform(subscriber.id, submission.id)
+    end
+  end
+end

--- a/spec/lib/tasks/adjust_status_spec.rb
+++ b/spec/lib/tasks/adjust_status_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "adjust:status", type: :task do
+  let(:notifier) { instance_double(NotifySubscriber, perform: true) }
+  let(:submission) { create(:submission, application_state: "granted") }
+  let(:subscriber) { create(:subscriber, subscriber_type: "caseworker") }
+  let(:args) { [submission.id, "rejected"] }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    allow(NotifySubscriber).to receive(:new).and_return(notifier)
+    subscriber
+    Rake::Task["adjust:status"].invoke(*args)
+  end
+
+  after do
+    Rake::Task["adjust:status"].reenable
+  end
+
+  it "updates the status" do
+    expect(submission.reload.application_state).to eq "rejected"
+  end
+
+  it "does not notify anyone by default" do
+    expect(notifier).not_to have_received(:perform)
+  end
+
+  context "when a different role to notify is specified" do
+    let(:args) { [submission.id, "rejected", "provider"] }
+
+    it "does not notify the subscriber" do
+      expect(notifier).not_to have_received(:perform)
+    end
+  end
+
+  context "when the same role to notify is specified" do
+    let(:args) { [submission.id, "rejected", "caseworker"] }
+
+    it "notifies the subscriber" do
+      expect(notifier).to have_received(:perform).with(subscriber.id, submission.id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ unless ENV["NOCOVERAGE"]
     add_filter "config/initializers/sentry.rb"
     add_filter "config/initializers/sidekiq.rb"
     add_filter "config/routes.rb"
+    add_filter "lib/tasks/"
     add_filter "spec/"
 
     enable_coverage :branch


### PR DESCRIPTION
## Description of change
We need to fix some data in the provider app, and rather than manually fix it in every other database we can push through an updated payload. BUT to do so we need to temporarily put affected submissions into a state that permits provider updates. This task lets us do this. Intended usage:

- Identify affected IDs in provider
- Use this to set status of those to `sent_back` WITHOUT sending notifications
- Run the fix in provider
- Use this to set the status of them back to their initial state, sending notifications to caseworker to make sure it ends up tracking the correct state.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1747)
