### PR TITLE
CRM457-1715: Add last_updated_at column, backfill and populate on submission create or update

### DIFF
--- a/app/services/submissions/creation_service.rb
+++ b/app/services/submissions/creation_service.rb
@@ -13,7 +13,8 @@ module Submissions
             version: 1,
           )
 
-          submission.update_columns(last_updated_at: submission.created_at)
+          last_updated_at = params.dig(:application, :updated_at)&.to_time || submission.created_at
+          submission.update_columns(last_updated_at:)
         end
         NotificationService.call(params[:application_id], role)
       end

--- a/app/services/submissions/creation_service.rb
+++ b/app/services/submissions/creation_service.rb
@@ -12,6 +12,8 @@ module Submissions
             application: params[:application],
             version: 1,
           )
+
+          submission.update_columns(last_updated_at: submission.created_at)
         end
         NotificationService.call(params[:application_id], role)
       end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -21,6 +21,7 @@ module Submissions
           event["updated_at"] ||= event["created_at"]
 
           submission.events << event.as_json
+          submission.last_updated_at = event["created_at"]
         end
         save && submission.save!
       end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -21,8 +21,10 @@ module Submissions
           event["updated_at"] ||= event["created_at"]
 
           submission.events << event.as_json
-          submission.last_updated_at = event["created_at"]
         end
+
+        latest_event = submission.events.max_by { |ev| ev["created_at"] }
+        submission.last_updated_at = latest_event["created_at"] if latest_event
         save && submission.save!
       end
 

--- a/db/migrate/20240716130539_add_last_updated_at_to_applications.rb
+++ b/db/migrate/20240716130539_add_last_updated_at_to_applications.rb
@@ -1,0 +1,5 @@
+class AddLastUpdatedAtToApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application, :last_updated_at, :datetime, precision: nil
+  end
+end

--- a/db/migrate/20240716130618_backfill_last_updated_at.rb
+++ b/db/migrate/20240716130618_backfill_last_updated_at.rb
@@ -1,0 +1,22 @@
+class BackfillLastUpdatedAt < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    Submission.unscoped.each do |submission|
+      # Update all last_updated_at columns to be the latest event date
+      # or, if no events exist, then the latest application version created_at date.
+      #
+      latest_event = submission.events&.max_by { |event| event['created_at'].to_time }
+
+      last_updated_at  = if latest_event
+        last_updated_at = latest_event['created_at'].to_time
+      else
+        submission.latest_version.created_at
+      end
+
+      submission.update_columns(last_updated_at:)
+
+      sleep(0.01) # throttle
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_095916) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_130618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_095916) do
     t.jsonb "events"
     t.datetime "created_at", precision: nil
     t.virtual "has_been_assigned_to", type: :jsonb, as: "jsonb_path_query_array(events, '$[*]?(@.\"event_type\" == \"assignment\").\"primary_user_id\"'::jsonpath)", stored: true
+    t.datetime "last_updated_at", precision: nil
     t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null", validate: false
     t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null", validate: false
   end

--- a/spec/requests/update_submission_spec.rb
+++ b/spec/requests/update_submission_spec.rb
@@ -13,27 +13,30 @@ RSpec.describe "Update submission" do
 
   it "updates events" do
     submission = create(:submission, application_state: "further_info")
-    patch "/v1/submissions/#{submission.id}",
-          params: {
-            application_state: "granted",
-            events: [
-              {
-                id: "123",
-                details: "foo",
-              },
-            ],
-            application: { new: :data },
-            json_schema_version: 1,
-          }
+    freeze_time do
+      patch "/v1/submissions/#{submission.id}",
+            params: {
+              application_state: "granted",
+              events: [
+                {
+                  id: "123",
+                  details: "foo",
+                },
+              ],
+              application: { new: :data },
+              json_schema_version: 1,
+            }
 
-    submission.reload
-    expect(submission.events.count).to eq 1
-    expect(submission.events.first).to include(
-      "id" => "123",
-      "details" => "foo",
-    )
-    expect(submission.application_state).to eq("granted")
-    expect(submission.ordered_submission_versions.count).to eq(2)
+      submission.reload
+      expect(submission.events.count).to eq 1
+      expect(submission.events.first).to include(
+        "id" => "123",
+        "details" => "foo",
+      )
+      expect(submission.application_state).to eq("granted")
+      expect(submission.ordered_submission_versions.count).to eq(2)
+      expect(submission.last_updated_at).to eql submission.events.first["created_at"].to_time
+    end
   end
 
   it "does not allow overwriting events" do


### PR DESCRIPTION
## Description of change
Add last_updated_at column, backfill and populate on submission create or update

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1715)

To allow searching and filtering on a top level
date value.
