### PR TITLE
CRM457-1761: Cope with leading spaces

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -10,7 +10,7 @@ class Search < ApplicationRecord
   def self.where_terms(string)
     return all unless string
 
-    sub_strings = string.downcase.split(/\s+/).map do |str|
+    sub_strings = string.strip.downcase.split(/\s+/).map do |str|
       if str.start_with?("laa-")
         clean_str = str.sub(/\Alaa-/, "laa")
         "#{clean_str}:A"

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -155,6 +155,26 @@ RSpec.describe Search do
       end
     end
 
+    context "when search text has a leading space" do
+      let(:query) { " joe" }
+
+      context "with prior authority application" do
+        let(:prepare) { build(:submission, :with_pa_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+
+      context "with non-standard magistrate application" do
+        let(:prepare) { build(:submission, :with_nsm_version).tap(&:save) }
+
+        it "returns the record" do
+          expect(search).to eq([prepare.id])
+        end
+      end
+    end
+
     context "when user name is Jason/Jim" do
       let(:query) { "Jason/Jim" }
 


### PR DESCRIPTION
## Description of change
A search query with a leading space was causing a 422 error from the app store. While arguably the client should strip whitespace, the app store shouldn't error out with a postgres error if it doesn't.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1761)
