### PR TITLE
Remove unneeded circleci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - build-docker-image-for-scan
       - snyk/install:
           token-variable: SNYK_TOKEN
       - run:


### PR DESCRIPTION

## Description of change
Remove unneeded circleci step

We are scanning the metabase image not the apps's built
image.

