### PR TITLE
Add additional helm chart/yaml linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,10 +341,10 @@ workflows:
   test-opened-pr:
     jobs:
       - install-helm:
-        filters:
-          branches:
-            ignore:
-              - main
+          filters:
+            branches:
+              ignore:
+                - main
       - lint-app:
           filters:
             branches:
@@ -397,10 +397,10 @@ workflows:
   test-build-deploy-merged-pr:
     jobs:
       - install-helm:
-        filters:
-          branches:
-            only:
-              - main
+          filters:
+            branches:
+              only:
+                - main
       - lint-app:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ commands:
           paths:
             - ~/.bundle
             - vendor/bundle
-      - *install-yamllint
 
   db-setup:
     steps:
@@ -183,6 +182,7 @@ jobs:
     steps:
       - checkout
       - install-requirements
+      - *install-yamllint
       - run-rubocop
       - lint-and-verify-helm-config:
           environment: development
@@ -222,8 +222,6 @@ jobs:
       - run:
           name: Monitor container image for vulnerabilities
           command: snyk container monitor app
-      - helm/install_helm_client:
-          version: 3.7.2
       - run:
           name: Test IaC files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,8 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
+        - helm/install_helm_client:
+            version: 3.7.2
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
@@ -174,13 +176,6 @@ commands:
               ./bin/deploy << parameters.environment >>
 
 jobs:
-  install-helm:
-    working_directory: ~/repo
-    executor: test-executor
-    steps:
-      - helm/install_helm_client:
-        version: 3.7.2
-
   lint-app:
     working_directory: ~/repo
     executor: test-executor
@@ -340,18 +335,11 @@ workflows:
 
   test-opened-pr:
     jobs:
-      - install-helm:
-        filters:
-          branches:
-            ignore:
-              - main
       - lint-app:
           filters:
             branches:
               ignore:
                 - main
-          requires:
-            - install-helm
       - test-app:
           filters:
             branches:
@@ -362,8 +350,6 @@ workflows:
             branches:
               ignore:
                 - main
-          requires:
-            - install-helm
       - scan-metabase-docker-image:
           filters:
             branches:
@@ -396,18 +382,11 @@ workflows:
 
   test-build-deploy-merged-pr:
     jobs:
-      - install-helm:
-        filters:
-          branches:
-            only:
-              - main
       - lint-app:
           filters:
             branches:
               only:
                 - main
-          requires:
-            - install-helm
       - test-app:
           filters:
             branches:
@@ -418,8 +397,6 @@ workflows:
             branches:
               only:
                 - main
-          requires:
-            - install-helm
       - scan-metabase-docker-image:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,6 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
-        - helm/install_helm_client:
-            version: 3.7.2
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
@@ -176,6 +174,13 @@ commands:
               ./bin/deploy << parameters.environment >>
 
 jobs:
+  install-helm:
+    working_directory: ~/repo
+    executor: test-executor
+    steps:
+      - helm/install_helm_client:
+        version: 3.7.2
+
   lint-app:
     working_directory: ~/repo
     executor: test-executor
@@ -335,11 +340,18 @@ workflows:
 
   test-opened-pr:
     jobs:
+      - install-helm:
+        filters:
+          branches:
+            ignore:
+              - main
       - lint-app:
           filters:
             branches:
               ignore:
                 - main
+          requires:
+            - install-helm
       - test-app:
           filters:
             branches:
@@ -350,6 +362,8 @@ workflows:
             branches:
               ignore:
                 - main
+          requires:
+            - install-helm
       - scan-metabase-docker-image:
           filters:
             branches:
@@ -382,11 +396,18 @@ workflows:
 
   test-build-deploy-merged-pr:
     jobs:
+      - install-helm:
+        filters:
+          branches:
+            only:
+              - main
       - lint-app:
           filters:
             branches:
               only:
                 - main
+          requires:
+            - install-helm
       - test-app:
           filters:
             branches:
@@ -397,6 +418,8 @@ workflows:
             branches:
               only:
                 - main
+          requires:
+            - install-helm
       - scan-metabase-docker-image:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,14 @@ references:
           kubectl config use-context ${K8S_CLUSTER_NAME}
           kubectl --namespace=${K8S_NAMESPACE} get pods
 
+  _install-yamllint: &install-yamllint
+    run:
+      name: Install yamllint to use to check yaml formatting issues
+      command: |
+        sudo apt update
+        sudo apt install -y python3-pip
+        pip install yamllint
+
 commands:
   install-requirements:
     steps:
@@ -104,11 +112,33 @@ commands:
           path: ~/repo/coverage
           destination: coverage
 
-  run-linting:
+  run-rubocop:
     steps:
       - run:
           name: Run rubocop
           command: bundle exec rubocop
+
+
+  # using a more recent version of yamllink so we can use the key_duplicates rule
+  # https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.key_duplicates
+
+  lint-and-verify-helm-config:
+      description:
+      parameters:
+        environment:
+          description: Name of environment to check helm template of
+          type: string
+      steps:
+        - helm/install_helm_client:
+            version: 3.7.2
+        - *install-yamllint
+        - run:
+            name: Lint helm chart for <<parameters.environment>>
+            command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
+        - run:
+            name: Check helm template for <<parameters.environment>>
+            command: helm template --debug helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml | yamllint -
+
 
   build-docker-image-for-scan:
     steps:
@@ -153,7 +183,13 @@ jobs:
     steps:
       - checkout
       - install-requirements
-      - run-linting
+      - run-rubocop
+      - lint-and-verify-helm-config:
+          environment: development
+      - lint-and-verify-helm-config:
+          environment: uat
+      - lint-and-verify-helm-config:
+          environment: production
 
   test-app:
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,8 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
+        - helm/install_helm_client:
+          version: 3.7.2
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,12 @@ commands:
       steps:
         - helm/install_helm_client:
             version: 3.7.2
-        - *install-yamllint
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
         - run:
             name: Check helm template for <<parameters.environment>>
-            command: helm template --debug helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml | yamllint -
+            command: helm template --debug helm_deploy --values helm_deploy/values-development.yaml | yamllint -
 
 
   build-docker-image-for-scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,10 +341,10 @@ workflows:
   test-opened-pr:
     jobs:
       - install-helm:
-          filters:
-            branches:
-              ignore:
-                - main
+        filters:
+          branches:
+            ignore:
+              - main
       - lint-app:
           filters:
             branches:
@@ -397,10 +397,10 @@ workflows:
   test-build-deploy-merged-pr:
     jobs:
       - install-helm:
-          filters:
-            branches:
-              only:
-                - main
+        filters:
+          branches:
+            only:
+              - main
       - lint-app:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,6 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
-        - helm/install_helm_client:
-          version: 3.7.2
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
@@ -224,6 +222,8 @@ jobs:
       - run:
           name: Monitor container image for vulnerabilities
           command: snyk container monitor app
+      - helm/install_helm_client:
+          version: 3.7.2
       - run:
           name: Test IaC files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ commands:
           paths:
             - ~/.bundle
             - vendor/bundle
+      - *install-yamllint
 
   db-setup:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,6 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
-        - helm/install_helm_client:
-            version: 3.7.2
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
@@ -184,6 +182,8 @@ jobs:
       - install-requirements
       - *install-yamllint
       - run-rubocop
+      - helm/install_helm_client:
+        version: 3.7.2
       - lint-and-verify-helm-config:
           environment: development
       - lint-and-verify-helm-config:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  trailing-spaces: disable
+  indentation: disable
+  brackets: disable
+  comments: disable
+  comments-indentation: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -13,7 +13,7 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app:  {{ include "laa-crime-application-store.fullname" . }}-worker
+      app: {{ include "laa-crime-application-store.fullname" . }}-worker
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -21,7 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app:  {{ include "laa-crime-application-store.fullname" . }}-worker
+        app: {{ include "laa-crime-application-store.fullname" . }}-worker
         metrics-target: {{ include "laa-crime-application-store.fullname" . }}-metrics-target
     spec:
       {{ if .Values.service_account.required }}


### PR DESCRIPTION
## Description of change

[Last outcome for this ticket](https://dsdmoj.atlassian.net/browse/CRM457-1547)

Note: this runs helm lint AND helm template (debug) because from my experience helm lint won't always necessarily catch issues that can break a chart (I tested helm lint on some misconfigurations and it didn't catch some of them) where helm template will AND helm template doesn't give us warning level suggestions like helm lint does - so both in tandem covers all bases for breaking changes and suggestions

Also including yamllint to check for things like duplicate keys upon suggestion from @elken[ in this PR](https://github.com/ministryofjustice/laa-submit-crime-forms/pull/1013)
