### PR TITLE
Add lock to add_events method

### DIFF
--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -12,20 +12,22 @@ module Submissions
       end
 
       def add_events(submission, params, save: false)
-        submission.events ||= []
-        params[:events]&.each do |event|
-          next if submission.events.any? { _1["id"] == event["id"] }
+        submission.with_lock do
+          submission.events ||= []
+          params[:events]&.each do |event|
+            next if submission.events.any? { _1["id"] == event["id"] }
 
-          event["submission_version"] ||= submission.current_version
-          event["created_at"] ||= Time.zone.now
-          event["updated_at"] ||= event["created_at"]
+            event["submission_version"] ||= submission.current_version
+            event["created_at"] ||= Time.zone.now
+            event["updated_at"] ||= event["created_at"]
 
-          submission.events << event.as_json
+            submission.events << event.as_json
+          end
+
+          latest_event = submission.events.max_by { |ev| ev["created_at"] }
+          submission.last_updated_at = latest_event["created_at"] if latest_event
+          save && submission.save!
         end
-
-        latest_event = submission.events.max_by { |ev| ev["created_at"] }
-        submission.last_updated_at = latest_event["created_at"] if latest_event
-        save && submission.save!
       end
 
       def add_new_version(submission, params)

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -32,7 +32,7 @@ module Submissions
 
     private
 
-      def process_events
+      def process_events(submission, params)
         submission.events ||= []
         params[:events]&.each do |event|
           next if submission.events.any? { _1["id"] == event["id"] }


### PR DESCRIPTION
## Description of change

[Status not being updated in JSON blob for expired/autogranted actions from CW](https://dsdmoj.atlassian.net/browse/CRM457-1827)

## Notes for reviewer
UpdateService#add_events did not lock the submission and therefore when executed alone could cause issues with the order of the submission being updated (causing data loss) - this ticket ensures the submission is locked add_events is occuring to ensure updates happen in the correct order
