### PR TITLE
CRM457-1844: Refactor out event additions and lock it

### DIFF
--- a/app/controllers/V1/events_controller.rb
+++ b/app/controllers/V1/events_controller.rb
@@ -1,7 +1,10 @@
 module V1
   class EventsController < ApplicationController
     def create
-      ::Submissions::UpdateService.add_events(current_submission, params, save: true)
+      current_submission.with_lock do
+        ::Submissions::EventAdditionService.call(current_submission, params)
+        current_submission.save!
+      end
       head :created
     end
 

--- a/app/services/submissions/event_addition_service.rb
+++ b/app/services/submissions/event_addition_service.rb
@@ -1,0 +1,22 @@
+module Submissions
+  class EventAdditionService
+    class << self
+      # Note that this service does NOT persist changes to the submission object
+      def call(submission, params)
+        submission.events ||= []
+        params[:events]&.each do |event|
+          next if submission.events.any? { _1["id"] == event["id"] }
+
+          event["submission_version"] ||= submission.current_version
+          event["created_at"] ||= Time.zone.now
+          event["updated_at"] ||= event["created_at"]
+
+          submission.events << event.as_json
+        end
+
+        latest_event = submission.events.max_by { |ev| ev["created_at"] }
+        submission.last_updated_at = latest_event["created_at"] if latest_event
+      end
+    end
+  end
+end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -4,28 +4,11 @@ module Submissions
       def call(submission, params, role)
         submission.with_lock do
           submission.current_version += 1
-          add_events(submission, params)
+          EventAdditionService.call(submission, params)
           submission.update!(params.permit(:application_state, :application_risk))
           add_new_version(submission, params)
         end
         NotificationService.call(params[:id], role)
-      end
-
-      def add_events(submission, params, save: false)
-        submission.events ||= []
-        params[:events]&.each do |event|
-          next if submission.events.any? { _1["id"] == event["id"] }
-
-          event["submission_version"] ||= submission.current_version
-          event["created_at"] ||= Time.zone.now
-          event["updated_at"] ||= event["created_at"]
-
-          submission.events << event.as_json
-        end
-
-        latest_event = submission.events.max_by { |ev| ev["created_at"] }
-        submission.last_updated_at = latest_event["created_at"] if latest_event
-        save && submission.save!
       end
 
       def add_new_version(submission, params)


### PR DESCRIPTION
## Description of change
Move event addition into its own service (calling it addition, not creation, because the service doesn't persist anything to the database), since it has its own area of responsibility that is now needed by multiple other things
Lock the record in the event creation endpoint

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1844)