### PR TITLE
CRM457-1847: Remove 'retry_on'

### DIFF
--- a/app/jobs/notify_subscriber.rb
+++ b/app/jobs/notify_subscriber.rb
@@ -1,6 +1,5 @@
 class NotifySubscriber < ApplicationJob
   ClientResponseError = Class.new(StandardError)
-  retry_on ClientResponseError, wait: :polynomially_longer, attempts: 10
 
   def perform(subscriber_id, submission_id)
     subscriber = Subscriber.find(subscriber_id)


### PR DESCRIPTION
retry_on is part of the ActiveJob DSL that causes errors to be swallowed until a certain number of retries, after which the error is allowed to bubble up to the underlying mechanism (in our case Sidekiq, which will report the error to Sentry) This isn't actually the behaviour we want - if a job is failing we want Sentry to be informed immediately the first time it fails, on the grounds that normally this is going to be the indication of a problem, not some harmless transient error, so we want as much heads up as possible.