### PR TITLE
CRM457-1905: Check submission state

### DIFF
--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -9,7 +9,7 @@ module Authorization
         submissions: {
           index: true,
           show: true,
-          create: true,
+          create: ->(_, params) { params[:application_state].in?(PERMITTED_INITIAL_SUBMISSION_STATES) },
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:provider]) },
         },
       },
@@ -50,6 +50,8 @@ module Authorization
         { pre: %w[sent_back provider_requested], post: %w[granted part_grant rejected] },
       ],
     }.freeze
+
+    PERMITTED_INITIAL_SUBMISSION_STATES = %w[submitted].freeze
 
     def self.state_pair_allowed?(object, params, pairs)
       pairs.any? do |pair|

--- a/app/services/submissions/creation_service.rb
+++ b/app/services/submissions/creation_service.rb
@@ -20,9 +20,8 @@ module Submissions
       end
 
       def initial_data(params)
-        params.permit(:application_type, :application_risk)
-              .merge(application_state: "submitted",
-                     current_version: 1,
+        params.permit(:application_type, :application_risk, :application_state)
+              .merge(current_version: 1,
                      id: params[:application_id])
       end
     end

--- a/spec/requests/create_submission_spec.rb
+++ b/spec/requests/create_submission_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Create submission" do
       post "/v1/submissions", params: {
         application_id: id,
         application_type: "crm4",
+        application_state: "submitted",
         application_risk: "low",
         json_schema_version: 1,
         application: { foo: :bar },
@@ -40,6 +41,7 @@ RSpec.describe "Create submission" do
         post "/v1/submissions", params: {
           application_id: id,
           application_type: "crm4",
+          application_state: "submitted",
           application_risk: "low",
           json_schema_version: 1,
           application: {
@@ -73,14 +75,29 @@ RSpec.describe "Create submission" do
     it "validates what I send" do
       post "/v1/submissions", params: {
         application_id: SecureRandom.uuid,
+        application_state: "submitted",
       }
       expect(response).to have_http_status :unprocessable_entity
+    end
+
+    it "detects a forbidden state" do
+      post "/v1/submissions", params: {
+        application_id: SecureRandom.uuid,
+        application_state: "granted",
+        application_type: "crm4",
+        application_risk: "low",
+        json_schema_version: 1,
+        application: { foo: :bar },
+      }
+
+      expect(response).to have_http_status :forbidden
     end
 
     it "detects conflicting information" do
       submission = create(:submission)
       post "/v1/submissions", params: {
         application_id: submission.id,
+        application_state: "submitted",
       }
       expect(response).to have_http_status :conflict
     end
@@ -89,6 +106,7 @@ RSpec.describe "Create submission" do
       create(:subscriber, subscriber_type: "caseworker")
       params = {
         application_id: SecureRandom.uuid,
+        application_state: "submitted",
         application_type: "crm4",
         application_risk: "low",
         json_schema_version: 1,
@@ -102,6 +120,7 @@ RSpec.describe "Create submission" do
       create(:subscriber, subscriber_type: "provider")
       params = {
         application_id: SecureRandom.uuid,
+        application_state: "submitted",
         application_type: "crm4",
         application_risk: "low",
         json_schema_version: 1,
@@ -123,6 +142,7 @@ RSpec.describe "Create submission" do
       create(:subscriber, subscriber_type: "caseworker")
       params = {
         application_id: SecureRandom.uuid,
+        application_state: "submitted",
         application_type: "crm4",
         application_risk: "low",
         json_schema_version: 1,
@@ -136,6 +156,7 @@ RSpec.describe "Create submission" do
       create(:subscriber, subscriber_type: "provider")
       params = {
         application_id: SecureRandom.uuid,
+        application_state: "submitted",
         application_type: "crm4",
         application_risk: "low",
         json_schema_version: 1,


### PR DESCRIPTION
## Description of change
We found an issue where submissions were sent to the app store with status 'draft'. But we didn't spot it immediately because we were silently 'correcting' the status in the state field, but not in the "blob".  Let's be more picky, and fail out immediately if we spot impermissible data

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1905)