### PR TITLE
Swallow output to stdout during tests for rake tasks

### DIFF
--- a/spec/lib/tasks/adjust_fix_expired_spec.rb
+++ b/spec/lib/tasks/adjust_fix_expired_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "adjust:fix_expired" do
+RSpec.describe "adjust:fix_expired", type: :task do
   before do
     load "spec/lib/tasks/adjust_fix_expired_data.rb"
   end

--- a/spec/lib/tasks/adjust_fix_provider_updated_spec.rb
+++ b/spec/lib/tasks/adjust_fix_provider_updated_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "adjust:fix_expired" do
+RSpec.describe "adjust:fix_expired", type: :task do
   before do
     load "spec/lib/tasks/adjust_fix_provider_updated_data.rb"
   end

--- a/spec/lib/tasks/adjust_update_state_spec.rb
+++ b/spec/lib/tasks/adjust_update_state_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "adjust:update_state" do
+RSpec.describe "adjust:update_state", type: :task do
   before do
     load "spec/lib/tasks/adjust_update_state_data.rb"
   end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 describe "fixes:", type: :task do
   before do
     Rails.application.load_tasks if Rake::Task.tasks.empty?
-
-    allow($stdout).to receive(:write) # silence output from rake tasks
   end
 
   describe "update_contact_email" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,9 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   require "webmock/rspec"
+
+  # swallow sdtdout to keep output from rspec clean
+  config.before(:each, type: :task) do
+    allow($stdout).to receive(:write)
+  end
 end


### PR DESCRIPTION

## Description of change
Silence output to console from testing of rake tasks

Rake tasks often having stdout output but this comes
out when running rspec and clutters the console.

## Notes for reviewer
