### PR TITLE
Crm457 1966 find incorrect refs

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -4,9 +4,10 @@ namespace :fixes do
     submissions_to_check = Submission.where("application.current_version > 2")
     submissions_to_check.each do |submission|
       versions = submission.ordered_submission_versions
+      original_ref = versions.last.application['laa_reference']
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
       if unique_references.count > 1
-        print "Submission ID: #{submission.id} Original Ref: #{versions.last.application['laa_reference']} All References: #{unique_references.join(",")}}"
+        print "Submission ID: #{submission.id} Original Ref: #{original_ref} All References: #{unique_references.join(",")}}"
       end
     end
   end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -5,6 +5,7 @@ namespace :fixes do
     submissions_to_check.each do |submission|
       versions = submission.ordered_submission_versions
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
+      binding.pry
       if unique_references.count > 1
         print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references.join(",")}}"
       end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -6,7 +6,7 @@ namespace :fixes do
       versions = submission.ordered_submission_versions
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq().sort
       if unique_references.count > 1
-        print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references.join(",")}}"
+        print "Submission ID: #{submission.id} Original Ref: #{versions.last.application['laa_reference']} All References: #{unique_references.join(",")}}"
       end
     end
   end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -4,8 +4,7 @@ namespace :fixes do
     submissions_to_check = Submission.where("application.current_version > 2")
     submissions_to_check.each do |submission|
       versions = submission.ordered_submission_versions
-      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
-      binding.pry
+      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq().sort
       if unique_references.count > 1
         print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references.join(",")}}"
       end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -1,4 +1,16 @@
 namespace :fixes do
+  desc "Find mismatched LAA references"
+  task find_mismatched_references: :environment do
+    submissions_to_check = Submission.where("application.current_version > 1")
+    submissions_to_check.each do |submission|
+      versions = submission.ordered_submission_versions
+      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
+      if unique_references.count > 1
+        print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references}}"
+      end
+    end
+  end
+
   desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"
   task :update_contact_email, [:id, :new_contact_email] => :environment do |_, args|
     submission = Submission.find(args[:id])

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -6,7 +6,7 @@ namespace :fixes do
       versions = submission.ordered_submission_versions
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
       if unique_references.count > 1
-        print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references}}"
+        print "Submission ID: #{submission.id} Original Ref: #{versions.first.application['laa_reference']} All References: #{unique_references.join(",")}}"
       end
     end
   end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -7,7 +7,7 @@ namespace :fixes do
       original_ref = versions.last.application['laa_reference']
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
       if unique_references.count > 1
-        print "Submission ID: #{submission.id} Original Ref: #{original_ref} All References: #{unique_references.join(",")}}"
+        puts "Submission ID: #{submission.id} Original Ref: #{original_ref} All References: #{unique_references.join(",")}"
       end
     end
   end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -1,7 +1,7 @@
 namespace :fixes do
   desc "Find mismatched LAA references"
   task find_mismatched_references: :environment do
-    submissions_to_check = Submission.where("application.current_version > 1")
+    submissions_to_check = Submission.where("application.current_version > 2")
     submissions_to_check.each do |submission|
       versions = submission.ordered_submission_versions
       unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -4,7 +4,7 @@ namespace :fixes do
     submissions_to_check = Submission.where("application.current_version > 2")
     submissions_to_check.each do |submission|
       versions = submission.ordered_submission_versions
-      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq().sort
+      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
       if unique_references.count > 1
         print "Submission ID: #{submission.id} Original Ref: #{versions.last.application['laa_reference']} All References: #{unique_references.join(",")}}"
       end

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -40,6 +40,21 @@ FactoryBot.define do
       end
     end
 
+    trait :with_fixed_ref_pa_application do
+      application do
+        build(:application,
+              :pa,
+              defendant_name:,
+              account_number:,
+              firm_name:,
+              solicitor:,
+              status:,
+              ufn: ufn || "010124/001",
+              service_type: "ae_consultant",
+              laa_reference: "LAA-654321")
+      end
+    end
+
     trait :with_custom_pa_application do
       application do
         build(:application,

--- a/spec/factories/submission_versions.rb
+++ b/spec/factories/submission_versions.rb
@@ -40,21 +40,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_fixed_ref_pa_application do
-      application do
-        build(:application,
-              :pa,
-              defendant_name:,
-              account_number:,
-              firm_name:,
-              solicitor:,
-              status:,
-              ufn: ufn || "010124/001",
-              service_type: "ae_consultant",
-              laa_reference: "LAA-654321")
-      end
-    end
-
     trait :with_custom_pa_application do
       application do
         build(:application,

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -19,7 +19,7 @@ describe "fixes:find_mismatched_references", type: :task do
   end
 
   it "prints out the correct information" do
-    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
+    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.sort.join(",")
     expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{additional_version.application['laa_reference']} All References: #{invalid_versions}}"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -21,7 +21,7 @@ describe "fixes:find_mismatched_references", type: :task do
 
   it "prints out the correct information" do
     invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
-    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: LAA-123456 All References: #{invalid_versions}}"
+    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: LAA-123456 All References: #{invalid_versions}"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -18,8 +18,9 @@ describe "fixes:find_mismatched_references", type: :task do
     Rake::Task["fixes:find_mismatched_references"].reenable
   end
 
-  it "prints out the correct submission ids" do
-    expected_output = Submission.all.sort_by(&:created_at).map(&:id).join(",")
+  it "prints out the correct information" do
+    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq().join(",")
+    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{additional_version.application['laa_reference']} All References: #{invalid_versions}}"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -2,15 +2,16 @@ require "rails_helper"
 
 describe "fixes:find_mismatched_references", type: :task do
   let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3) }
-  let(:additional_version) { create(:submission_version, :with_pa_application, submission: valid_submission) }
   let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 3) }
-  let(:additional_invalid_version) { create(:submission_version, laa_reference: "LAA-654321", submission: invalid_submission) }
+  let(:additional_invalid_version) { create(:submission_version, laa_reference: "LAA-654321", version: 2, submission: invalid_submission) }
 
   before do
     valid_submission
-    additional_version
+    create(:submission_version, :with_pa_application, version: 2, submission: valid_submission)
+    create(:submission_version, :with_pa_application, version: 3, submission: valid_submission)
     invalid_submission
-    additional_invalid_version
+    create(:submission_version, laa_reference: "LAA-654321", version: 2, submission: invalid_submission)
+    create(:submission_version, laa_reference: "LAA-654321", version: 2, submission: invalid_submission)
     Rails.application.load_tasks if Rake::Task.tasks.empty?
   end
 

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 describe "fixes:find_mismatched_references", type: :task do
-  let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3) }
-  let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 3) }
-  let(:additional_invalid_version) { create(:submission_version, laa_reference: "LAA-654321", version: 2, submission: invalid_submission) }
+  let(:valid_reference) { "LAA-123456" }
+  let(:invalid_reference) { "LAA-ABCDEF" }
+  let(:changed_reference) { "LAA-654321" }
+  let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3, laa_reference: valid_reference) }
+  let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 3, laa_reference: invalid_reference) }
+  let(:additional_invalid_version) { create(:submission_version, laa_reference: changed_reference, version: 2, submission: invalid_submission) }
 
   before do
     valid_submission
@@ -21,7 +24,7 @@ describe "fixes:find_mismatched_references", type: :task do
 
   it "prints out the correct information" do
     invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
-    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: LAA-123456 All References: #{invalid_versions}"
+    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{invalid} All References: #{invalid_versions}\n"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -19,7 +19,7 @@ describe "fixes:find_mismatched_references", type: :task do
   end
 
   it "prints out the correct information" do
-    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq().join(",")
+    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
     expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{additional_version.application['laa_reference']} All References: #{invalid_versions}}"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -19,8 +19,8 @@ describe "fixes:find_mismatched_references", type: :task do
   end
 
   it "prints out the correct information" do
-    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.sort.join(",")
-    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{additional_version.application['laa_reference']} All References: #{invalid_versions}}"
+    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
+    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: LAA-123456 All References: #{invalid_versions}}"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "fixes:find_mismatched_references", type: :task do
+  let(:valid_submission) { create(:submission, :with_pa_version, current_version: 2) }
+  let(:additional_version) { create(:submission_version, :with_pa_application, submission: valid_submission) }
+  let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 2) }
+  let(:additional_invalid_version) { create(:submission_version, :with_fixed_ref_pa_application, submission: invalid_submission) }
+
+  before do
+    valid_submission
+    additional_version
+    invalid_submission
+    additional_invalid_version
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  after do
+    Rake::Task["fixes:find_mismatched_references"].reenable
+  end
+
+  it "prints out the correct submission ids" do
+    expected_output = Submission.all.sort_by(&:created_at).map(&:id).join(",")
+    expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
+  end
+end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe "fixes:find_mismatched_references", type: :task do
-  let(:valid_submission) { create(:submission, :with_pa_version, current_version: 2) }
+  let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3) }
   let(:additional_version) { create(:submission_version, :with_pa_application, submission: valid_submission) }
-  let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 2) }
-  let(:additional_invalid_version) { create(:submission_version, submission: invalid_submission, laa_reference: "LAA-654321") }
+  let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 3) }
+  let(:additional_invalid_version) { create(:submission_version, laa_reference: "LAA-654321", submission: invalid_submission) }
 
   before do
     valid_submission

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -24,7 +24,7 @@ describe "fixes:find_mismatched_references", type: :task do
 
   it "prints out the correct information" do
     invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
-    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{invalid} All References: #{invalid_versions}\n"
+    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{invalid_reference} All References: #{invalid_versions}\n"
     expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -4,7 +4,7 @@ describe "fixes:find_mismatched_references", type: :task do
   let(:valid_submission) { create(:submission, :with_pa_version, current_version: 2) }
   let(:additional_version) { create(:submission_version, :with_pa_application, submission: valid_submission) }
   let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 2) }
-  let(:additional_invalid_version) { create(:submission_version, :with_fixed_ref_pa_application, submission: invalid_submission) }
+  let(:additional_invalid_version) { create(:submission_version, submission: invalid_submission, laa_reference: "LAA-654321") }
 
   before do
     valid_submission

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Rails.root.glob("spec/support/**/*.rb").each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.


### PR DESCRIPTION
## Description of change

[Part 1 of ticket](https://dsdmoj.atlassian.net/browse/CRM457-1966)

## Notes for reviewer
Task generates a list of submissions that have mismatched laa_references between versions, shows the original version's reference and a list of all the references associated
The results will be used for each of the data fixing tasks in all the service dbs so we can associated the submissions with their original version