### PR TITLE
Crm457 1966 fix incorrect refs

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -18,6 +18,7 @@ namespace :fixes do
 
     desc "Fix mismatched LAA references from list of submission ids"
     task manual_fix: :environment do
+      # populate affected_submission_ids with array of submission id strings that need fixing
       affected_submission_ids = []
       affected_submission_ids.each do |submission_id|
         submission = Submission.find(submission_id)

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -15,12 +15,17 @@ namespace :fixes do
         submission = entry['submission']
         original_ref = entry['original_ref']
         if entry.present? && original_ref.present?
+          puts "Fixing #{entry}"
           versions_to_fix = SubmissionVersion.where({application_id: submission.id})
           versions_to_fix.each do |version|
             current_ref = version.application['laa_reference']
             if current_ref != original_ref
-              version.application['laa_reference'] = original_ref
-              version.save!(touch: false)
+              fixed_application = version.application
+              fixed_application['laa_reference'] = original_ref
+              version.application = fixed_application
+              if version.save!(touch: false)
+                puts "Fixed Submission #{version.id}"
+              end
             end
           end
         end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -8,6 +8,25 @@ namespace :fixes do
       end
     end
 
+    desc "Fix mismatched LAA references"
+    task fix: :environment do
+      mismatched_submissions = get_mismatched_submissions
+      mismatched_submissions.each do |entry|
+        submission = entry['submission']
+        original_ref = entry['original_ref']
+        if entry.present? && original_ref.present?
+          versions_to_fix = SubmissionVersion.where({application_id: submission.id})
+          versions_to_fix.each do |version|
+            current_ref = version.application['laa_reference']
+            if current_ref != original_ref
+              version.application['laa_reference'] = original_ref
+              version.save!(touch: false)
+            end
+          end
+        end
+      end
+    end
+
     def get_mismatched_submissions
       faulty_submissions = []
       submissions_to_check = Submission.where("application.current_version > 2")

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -8,26 +8,22 @@ namespace :fixes do
       end
     end
 
-    desc "Fix mismatched LAA references"
-    task fix: :environment do
+    desc "Fix mismatched LAA references by scanning for mismatches"
+    task auto_fix: :environment do
       mismatched_submissions = get_mismatched_submissions
       mismatched_submissions.each do |entry|
-        submission = entry['submission']
-        original_ref = entry['original_ref']
-        if entry.present? && original_ref.present?
-          puts "Fixing #{entry}"
-          versions_to_fix = SubmissionVersion.where({application_id: submission.id})
-          versions_to_fix.each do |version|
-            current_ref = version.application['laa_reference']
-            if current_ref != original_ref
-              fixed_application = version.application
-              fixed_application['laa_reference'] = original_ref
-              version.application = fixed_application
-              if version.save!(touch: false)
-                puts "Fixed Submission #{version.id}"
-              end
-            end
-          end
+        fix_entry(entry)
+      end
+    end
+
+    desc "Fix mismatched LAA references from list of submission ids"
+    task manual_fix: :environment do
+      affected_submission_ids = []
+      affected_submission_ids.each do |submission_id|
+        submission = Submission.find(submission_id)
+        if submission
+          entry = submission_details(submission_id)
+          fix_entry(entry)
         end
       end
     end
@@ -36,17 +32,42 @@ namespace :fixes do
       faulty_submissions = []
       submissions_to_check = Submission.where("application.current_version > 2")
       submissions_to_check.each do |submission|
-        versions = submission.ordered_submission_versions
-        original_ref = versions.last.application['laa_reference']
-        unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
-        if unique_references.count > 1
-          entry = { 'submission' => submission, 'original_ref' => original_ref, 'unique_references' => unique_references}
+        entry = submission_details(submission)
+        if entry['unique_references'].count > 1
           faulty_submissions.push entry
         end
       end
       faulty_submissions
     end
+
+    def submission_details(submission)
+      versions = submission.ordered_submission_versions
+      original_ref = versions.last.application['laa_reference']
+      unique_references = versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq()
+      { 'submission' => submission, 'original_ref' => original_ref, 'unique_references' => unique_references}
+    end
+
+    def fix_entry(entry)
+      submission = entry['submission']
+      original_ref = entry['original_ref']
+      if entry.present? && original_ref.present?
+        puts "Fixing #{entry}"
+        versions_to_fix = SubmissionVersion.where({application_id: submission.id})
+        versions_to_fix.each do |version|
+          current_ref = version.application['laa_reference']
+          if current_ref != original_ref
+            fixed_application = version.application
+            fixed_application['laa_reference'] = original_ref
+            version.application = fixed_application
+            if version.save!(touch: false)
+              puts "Fixed Submission #{version.id}"
+            end
+          end
+        end
+      end
+    end
   end
+
   desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"
   task :update_contact_email, [:id, :new_contact_email] => :environment do |_, args|
     submission = Submission.find(args[:id])

--- a/spec/lib/tasks/auto_fix_mismatched_references_spec.rb
+++ b/spec/lib/tasks/auto_fix_mismatched_references_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "fixes:mismatched_references:fix", type: :task do
+describe "fixes:mismatched_references:auto_fix", type: :task do
   let(:valid_reference) { "LAA-123456" }
   let(:invalid_reference) { "LAA-ABCDEF" }
   let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3, laa_reference: valid_reference) }
@@ -17,11 +17,11 @@ describe "fixes:mismatched_references:fix", type: :task do
   end
 
   after do
-    Rake::Task["fixes:mismatched_references:find"].reenable
+    Rake::Task["fixes:mismatched_references:auto_fix"].reenable
   end
 
   it "invalid laa references are corrected" do
-    Rake::Task["fixes:mismatched_references:fix"].execute
+    Rake::Task["fixes:mismatched_references:auto_fix"].execute
     valid_versions = valid_submission.ordered_submission_versions.map(&:application)
     fixed_versions = invalid_submission.ordered_submission_versions.map(&:application)
     expect(valid_versions.select { _1["laa_reference"] == valid_reference }.count).to eq(3)

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "fixes:find_mismatched_references", type: :task do
+describe "fixes:mismatched_references:find", type: :task do
   let(:valid_reference) { "LAA-123456" }
   let(:invalid_reference) { "LAA-ABCDEF" }
   let(:changed_reference) { "LAA-654321" }
@@ -19,12 +19,12 @@ describe "fixes:find_mismatched_references", type: :task do
   end
 
   after do
-    Rake::Task["fixes:find_mismatched_references"].reenable
+    Rake::Task["fixes:mismatched_references:find"].reenable
   end
 
   it "prints out the correct information" do
     invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
     expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{invalid_reference} All References: #{invalid_versions}\n"
-    expect { Rake::Task["fixes:find_mismatched_references"].execute }.to output(expected_output).to_stdout
+    expect { Rake::Task["fixes:mismatched_references:find"].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/fix_mismatched_references_spec.rb
+++ b/spec/lib/tasks/fix_mismatched_references_spec.rb
@@ -24,7 +24,7 @@ describe "fixes:mismatched_references:fix", type: :task do
     Rake::Task["fixes:mismatched_references:fix"].execute
     valid_versions = valid_submission.ordered_submission_versions.map(&:application)
     fixed_versions = invalid_submission.ordered_submission_versions.map(&:application)
-    expect(valid_versions.select{ _1['laa_reference'] == valid_reference}.count).to eq(3)
-    expect(fixed_versions.select{ _1['laa_reference'] == invalid_reference}.count).to eq(3)
+    expect(valid_versions.select { _1["laa_reference"] == valid_reference }.count).to eq(3)
+    expect(fixed_versions.select { _1["laa_reference"] == invalid_reference }.count).to eq(3)
   end
 end

--- a/spec/lib/tasks/fix_mismatched_references_spec.rb
+++ b/spec/lib/tasks/fix_mismatched_references_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
-describe "fixes:mismatched_references:find", type: :task do
+describe "fixes:mismatched_references:fix", type: :task do
   let(:valid_reference) { "LAA-123456" }
   let(:invalid_reference) { "LAA-ABCDEF" }
-  let(:changed_reference) { "LAA-654321" }
   let(:valid_submission) { create(:submission, :with_pa_version, current_version: 3, laa_reference: valid_reference) }
   let(:invalid_submission) { create(:submission, :with_pa_version, current_version: 3, laa_reference: invalid_reference) }
 
@@ -21,9 +20,11 @@ describe "fixes:mismatched_references:find", type: :task do
     Rake::Task["fixes:mismatched_references:find"].reenable
   end
 
-  it "prints out the correct information" do
-    invalid_versions = invalid_submission.ordered_submission_versions.pluck(Arel.sql("application -> 'laa_reference'")).uniq.join(",")
-    expected_output = "Submission ID: #{invalid_submission.id} Original Ref: #{invalid_reference} All References: #{invalid_versions}\n"
-    expect { Rake::Task["fixes:mismatched_references:find"].execute }.to output(expected_output).to_stdout
+  it "invalid laa references are corrected" do
+    Rake::Task["fixes:mismatched_references:fix"].execute
+    valid_versions = valid_submission.ordered_submission_versions.map(&:application)
+    fixed_versions = invalid_submission.ordered_submission_versions.map(&:application)
+    expect(valid_versions.select{ _1['laa_reference'] == valid_reference}.count).to eq(3)
+    expect(fixed_versions.select{ _1['laa_reference'] == invalid_reference}.count).to eq(3)
   end
 end


### PR DESCRIPTION
## Description of change

[Part 3 - Fix Records in App Store](https://dsdmoj.atlassian.net/browse/CRM457-1966)

- Fixes app store SubmissionVersions in RFI where laa_reference doesn't match between version (applies original laa_reference to all versions)
- Has a manual version that doesn't use check in case we need to use that


