### PR TITLE
[CRM457-1945] CRM7 Caseworker: Update search/filter with risk rating

### DIFF
--- a/app/controllers/V1/submissions/searches_controller.rb
+++ b/app/controllers/V1/submissions/searches_controller.rb
@@ -24,6 +24,7 @@ module V1
           :submitted_to,
           :updated_from,
           :updated_to,
+          :risk,
           :caseworker_id,
           :status_with_assignment,
         )

--- a/app/services/submissions/search_service.rb
+++ b/app/services/submissions/search_service.rb
@@ -27,9 +27,19 @@ module Submissions
       relation = relation.where(status_with_assignment:) if status_with_assignment
       relation = relation.where(risk:) if risk
       relation = relation.where("has_been_assigned_to ? :caseworker_id", caseworker_id:) if caseworker_id
-      relation = relation.order(sort_clause)
+      relation = sort_results(relation)
 
       relation.where_terms(query)
+    end
+
+    def sort_results(relation)
+      case sort_by
+      when "risk"
+        direction = sort_direction == "asc" ? %w[high medium low] : %w[low medium high]
+        relation.in_order_of(:risk, direction)
+      else
+        relation.order(sort_clause)
+      end
     end
 
     def search_results

--- a/app/services/submissions/search_service.rb
+++ b/app/services/submissions/search_service.rb
@@ -1,6 +1,6 @@
 module Submissions
   class SearchService
-    SORTABLE_COLUMNS = %w[laa_reference firm_name client_name last_updated status_with_assignment].freeze
+    SORTABLE_COLUMNS = %w[laa_reference firm_name client_name last_updated status_with_assignment risk].freeze
 
     attr_reader :search_params
 
@@ -25,6 +25,7 @@ module Submissions
       relation = relation.where(last_updated: (updated_from..updated_to))
       relation = relation.where(application_type:) if application_type
       relation = relation.where(status_with_assignment:) if status_with_assignment
+      relation = relation.where(risk:) if risk
       relation = relation.where("has_been_assigned_to ? :caseworker_id", caseworker_id:) if caseworker_id
       relation = relation.order(sort_clause)
 
@@ -85,6 +86,10 @@ module Submissions
 
     def query
       search_params[:query]
+    end
+
+    def risk
+      search_params[:risk]
     end
 
     def sort_clause

--- a/spec/requests/submissions_search_spec.rb
+++ b/spec/requests/submissions_search_spec.rb
@@ -368,6 +368,29 @@ RSpec.describe "Submission search" do
       end
     end
 
+    context "with risk filter" do
+      before do
+        create(:submission, :with_nsm_version,
+               application_risk: "high")
+
+        create(:submission, :with_nsm_version,
+               application_risk: "low")
+
+        create(:submission, :with_nsm_version,
+               application_risk: "medium")
+      end
+
+      it "brings back only those with a matching risk" do
+        post search_endpoint, params: {
+          application_type: "crm7",
+          risk: "high",
+        }
+
+        expect(response.parsed_body["data"].size).to be 1
+        expect(response.parsed_body["data"].pluck("risk")).to all(include("high"))
+      end
+    end
+
     context "with defendant name query for PA" do
       before do
         create(:submission, :with_pa_version,


### PR DESCRIPTION
## Description of change

DO NOT MERGE refers to: https://dsdmoj.atlassian.net/browse/CRM457-2086

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1945)

relates to https://github.com/ministryofjustice/laa-assess-crime-forms/pull/771 

includes `risk` within returned search results

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:


### After changes:

## How to manually test the feature
