### PR TITLE
Update Alpine Build & Disable Docker Layer Caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/laa_crime_application_store_test
           TZ: Europe/London
-      - image: cimg/postgres:13.12-postgis
+      - image: cimg/postgres:16.4-postgis
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - snyk/install:
           token-variable: SNYK_TOKEN
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
-      - build-docker-image-for-scan
       - snyk/install:
           token-variable: SNYK_TOKEN
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - build-docker-image-for-scan
       - snyk/install:
           token-variable: SNYK_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  snyk: snyk/snyk@2.1.0
+  snyk: snyk/snyk@2.2.0
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
   aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
   crime-forms-end-to-end-tests: ministryofjustice/crime-forms-end-to-end-tests@volatile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
+      - build-docker-image-for-scan
       - snyk/install:
           token-variable: SNYK_TOKEN
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.5-alpine3.20 AS base
+FROM ruby:3.3.5-alpine3.19 AS base
 LABEL maintainer="Non-standard magistrates' court payment team"
 
 # TODO: is this still needed?

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.5-alpine3.19 AS base
+FROM ruby:3.3.5-alpine3.20 AS base
 LABEL maintainer="Non-standard magistrates' court payment team"
 
 # TODO: is this still needed?


### PR DESCRIPTION
- Update Snyk CLI from snyk/snyk@2.1.0 to snyk/snyk@2.2.0 (optional)
- Update test executor postgres image from postgres:13.12-postgis to postgres:16.4-postgis (optional)
- Update docker image base from ruby:3.3.5-alpine3.19 to ruby:3.3.5-alpine3.20 (optional but welcome - should be using as up to date image as possible)
- Disable docker layer caching (needed - snyk is saving very old versions of the image, even after updates)
- Add build-docker-image-for-scan back into scan-docker-image step so that new image is brought in after cached image is removed (needed)
- Remove build-docker-image-for-scan from scan-metabase-docker-image, it's redundant (optional but welcome)