### PR TITLE
CRM457-2066: Allow metadata updates

### DIFF
--- a/app/controllers/V1/submissions_controller.rb
+++ b/app/controllers/V1/submissions_controller.rb
@@ -25,6 +25,13 @@ module V1
       render json: { errors: e.message }, status: :unprocessable_entity
     end
 
+    def metadata
+      ::Submissions::MetadataUpdateService.call(current_submission, params)
+      head :ok
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { errors: e.message }, status: :unprocessable_entity
+    end
+
     def current_submission
       @current_submission ||= Submission.find(params[:id])
     end

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -21,6 +21,7 @@ module Authorization
         submissions: {
           index: true,
           show: true,
+          metadata: true,
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:caseworker]) },
         },
         events: {

--- a/app/services/submissions/metadata_update_service.rb
+++ b/app/services/submissions/metadata_update_service.rb
@@ -1,0 +1,10 @@
+module Submissions
+  class MetadataUpdateService
+    class << self
+      def call(submission, params)
+        EventAdditionService.call(submission, params)
+        submission.update!(params.permit(:application_risk))
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   namespace "v1" do
     resources :submissions, only: %i[show create index update] do
       resources :events, only: %i[create]
+      member { patch :metadata }
     end
     resources :subscribers, only: %i[create]
     delete :subscribers, to: "subscribers#destroy"

--- a/spec/requests/update_submission_metadata_spec.rb
+++ b/spec/requests/update_submission_metadata_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Update submission metadata" do
+  before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role:) }
+
+  context "when I am a caseworker" do
+    let(:role) { :caseworker }
+
+    it "lets me update the application risk" do
+      submission = create(:submission, application_risk: "low")
+      patch "/v1/submissions/#{submission.id}/metadata", params: { application_risk: "high" }
+      expect(response).to have_http_status(:ok)
+      expect(submission.reload.current_version).to eq 1
+      expect(submission.application_risk).to eq("high")
+    end
+
+    it "adds an event and bumps last updated at" do
+      event_date = Time.zone.local(2024, 9, 1, 10, 30)
+      submission = create(:submission, application_risk: "low")
+      patch "/v1/submissions/#{submission.id}/metadata",
+            params: { events: [{ id: "1", details: "2", created_at: event_date }] }
+      expect(response).to have_http_status(:ok)
+      expect(submission.reload.events).to contain_exactly(
+        hash_including("id" => "1", "details" => "2"),
+      )
+      expect(submission.last_updated_at).to eq event_date
+    end
+
+    it "validates" do
+      submission = create(:submission, application_risk: "low")
+      patch "/v1/submissions/#{submission.id}/metadata", params: { application_risk: nil }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(submission.application_risk).to eq("low")
+    end
+  end
+
+  context "when I am a provider" do
+    let(:role) { :provider }
+
+    it "does not let me update the application risk" do
+      submission = create(:submission, application_risk: "high")
+      patch "/v1/submissions/#{submission.id}/metadata", params: { application_risk: "low" }
+      expect(response).to have_http_status(:forbidden)
+      expect(submission.reload.application_risk).to eq("high")
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
So we can sync back risk updates to the app store.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2066)
