### PR TITLE
CRM457-2090: Loosen event appending rules

### DIFF
--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -25,7 +25,7 @@ module Authorization
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:caseworker]) },
         },
         events: {
-          create: ->(object, _params) { object.state.in?(%w[submitted provider_updated]) },
+          create: ->(object, _params) { object.state.in?(%w[submitted sent_back provider_updated]) },
         },
         searches: {
           create: true,


### PR DESCRIPTION
## Description of change
Because caseworkers need to generate assignment events for sent-back NSM claims (for claims that are sent back before NSM RFI loops are implemented so do not enter `provider_updated` status when the provider has emailed through their updates.)

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2090)
