### PR TITLE
CRM457-2094: Make job enqueueings atomic

### DIFF
--- a/app/jobs/notify_subscriber.rb
+++ b/app/jobs/notify_subscriber.rb
@@ -26,9 +26,7 @@ class NotifySubscriber < ApplicationJob
     subscriber.failed_attempts += 1
     subscriber.save!
 
-    return false if delete_subscriber(subscriber)
-
-    true
+    !delete_subscriber(subscriber)
   end
 
   def send_message_to_webhook(webhook_url, submission)

--- a/app/jobs/notify_subscriber.rb
+++ b/app/jobs/notify_subscriber.rb
@@ -3,13 +3,12 @@ class NotifySubscriber < ApplicationJob
 
   def self.perform_later(subscriber_id, submission)
     submission.update!(notify_subscriber_completed: false)
-    super(subscriber_id, submission.id)
+    super
   end
 
-  def perform(subscriber_id, submission_id)
+  def perform(subscriber_id, submission)
     raise_error = false
     subscriber = Subscriber.find(subscriber_id)
-    submission = Submission.find(submission_id)
     # This lock is important because it forces the job to wait until
     # the locked transaction that enqueued this job is released,
     # ensuring that when this job runs it is working with fresh
@@ -20,7 +19,7 @@ class NotifySubscriber < ApplicationJob
       submission.update!(notify_subscriber_completed: false)
     end
 
-    raise ClientResponseError, "Failed to notify subscriber about #{submission_id} - #{subscriber.webhook_url} returned error" if raise_error
+    raise ClientResponseError, "Failed to notify subscriber about #{submission.id} - #{subscriber.webhook_url} returned error" if raise_error
   end
 
   def handle_failure(subscriber)

--- a/app/jobs/notify_subscriber.rb
+++ b/app/jobs/notify_subscriber.rb
@@ -16,7 +16,7 @@ class NotifySubscriber < ApplicationJob
     submission.with_lock do
       raise_error = handle_failure(subscriber) unless send_message_to_webhook(subscriber.webhook_url, submission)
 
-      submission.update!(notify_subscriber_completed: false)
+      submission.update!(notify_subscriber_completed: true)
     end
 
     raise ClientResponseError, "Failed to notify subscriber about #{submission.id} - #{subscriber.webhook_url} returned error" if raise_error

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,8 +1,8 @@
 class NotificationService
   class << self
-    def call(submission_id, role)
+    def call(submission, role)
       Subscriber.where.not(subscriber_type: role).find_each do |subscriber|
-        NotifySubscriber.perform_later(subscriber.id, submission_id)
+        NotifySubscriber.perform_later(subscriber.id, submission)
       end
     end
   end

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -7,8 +7,8 @@ module Submissions
           EventAdditionService.call(submission, params)
           submission.update!(params.permit(:application_risk).merge(state: params[:application_state]))
           add_new_version(submission, params)
+          NotificationService.call(submission, role)
         end
-        NotificationService.call(params[:id], role)
       end
 
       def add_new_version(submission, params)

--- a/spec/jobs/notify_subscriber_spec.rb
+++ b/spec/jobs/notify_subscriber_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe NotifySubscriber do
         body: { submission_id: submission.id, data: submission.as_json },
       ).to_return(status: 200)
 
-      job.perform(subscriber.id, submission.id)
+      job.perform(subscriber.id, submission)
       expect(stub).to have_been_requested
     end
 
@@ -37,13 +37,13 @@ RSpec.describe NotifySubscriber do
       end
 
       it "raises an error if a non-200 status is returned" do
-        expect { job.perform(subscriber.id, submission.id) }.to raise_error NotifySubscriber::ClientResponseError
+        expect { job.perform(subscriber.id, submission) }.to raise_error NotifySubscriber::ClientResponseError
       end
 
       it "bumps the failed_attempts count" do
         expect {
           begin
-            job.perform(subscriber.id, submission.id)
+            job.perform(subscriber.id, submission)
           rescue NotifySubscriber::ClientResponseError
             nil
           end
@@ -61,11 +61,11 @@ RSpec.describe NotifySubscriber do
           before { subscriber.update(failed_attempts: 1) }
 
           it "raises no error" do
-            expect { job.perform(subscriber.id, submission.id) }.not_to raise_error
+            expect { job.perform(subscriber.id, submission) }.not_to raise_error
           end
 
           it "deletes the subscriber" do
-            job.perform(subscriber.id, submission.id)
+            job.perform(subscriber.id, submission)
             expect(Subscriber.find_by(id: subscriber.id)).to be_nil
           end
         end
@@ -78,7 +78,7 @@ RSpec.describe NotifySubscriber do
       end
 
       it "raises an appropriate error" do
-        expect { job.perform(subscriber.id, submission.id) }.to raise_error NotifySubscriber::ClientResponseError
+        expect { job.perform(subscriber.id, submission) }.to raise_error NotifySubscriber::ClientResponseError
       end
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe NotifySubscriber do
       token_stub
       webhook_stub
 
-      job.perform(subscriber.id, submission.id)
+      job.perform(subscriber.id, submission)
 
       expect(token_stub).to have_been_requested
       expect(webhook_stub).to have_been_requested
@@ -125,7 +125,7 @@ RSpec.describe NotifySubscriber do
       token_stub
       webhook_stub
 
-      2.times { job.perform(subscriber.id, submission.id) }
+      2.times { job.perform(subscriber.id, submission) }
 
       expect(token_stub).to have_been_requested.once
     end

--- a/spec/jobs/notify_subscriber_spec.rb
+++ b/spec/jobs/notify_subscriber_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotifySubscriber do
 
   describe ".perform_later" do
     it "sets a flag" do
-      described_class.perform_later(subscriber.id, submission.id)
+      described_class.perform_later(subscriber.id, submission)
       expect(submission.reload.notify_subscriber_completed).to be false
     end
   end


### PR DESCRIPTION
## Description of change
So that if there's a Redis issue we won't end up in an inconsistent state.
Note a few refactorings to make sure things stay locked in the right places etc

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2094)
