### PR TITLE
Stop locking submission while notifying

### DIFF
--- a/app/services/submissions/creation_service.rb
+++ b/app/services/submissions/creation_service.rb
@@ -5,16 +5,14 @@ module Submissions
       def call(params, role)
         raise AlreadyExistsError if Submission.find_by(id: params[:application_id])
 
-        Submission.transaction do
-          submission = Submission.create!(initial_data(params))
-          submission.with_lock do
-            add_version(submission, params)
+        submission = Submission.create!(initial_data(params))
+        submission.with_lock do
+          add_version(submission, params)
 
-            last_updated_at = params.dig(:application, :updated_at)&.to_time || submission.created_at
-            submission.update_columns(last_updated_at:)
-            NotificationService.call(submission, role)
-          end
+          last_updated_at = params.dig(:application, :updated_at)&.to_time || submission.created_at
+          submission.update_columns(last_updated_at:)
         end
+        NotificationService.call(submission, role)
       end
 
       def initial_data(params)

--- a/app/services/submissions/update_service.rb
+++ b/app/services/submissions/update_service.rb
@@ -7,8 +7,8 @@ module Submissions
           EventAdditionService.call(submission, params)
           submission.update!(params.permit(:application_risk).merge(state: params[:application_state]))
           add_new_version(submission, params)
-          NotificationService.call(submission, role)
         end
+        NotificationService.call(submission, role)
       end
 
       def add_new_version(submission, params)


### PR DESCRIPTION
## Description of change
The E2E tests run sidekiq jobs synchronously. Locking the submission while notifying subscribers means if the subscriber makes a synchronous call back to the app store that modifies the submission, we get a deadlock.

If the notify subscriber job doesn't lock, then we can't call it inside another lock, otherwise it may run with non-fresh data (if it runs before the outer lock has been released).

So we move the calls to NotifySubscriber outside locks. This means if Redis is down the DB will be updated without the job queue being updated, so the apps will get out of sync with one another. However our `notify_subscriber_completed` flag will give us a paper trail to fix this problem if it occurs

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2176)
