### PR TITLE
Return service column as text instead of json representation

### DIFF
--- a/db/migrate/20241105152058_update_submission_by_services_to_version_3.rb
+++ b/db/migrate/20241105152058_update_submission_by_services_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateSubmissionByServicesToVersion3 < ActiveRecord::Migration[7.2]
+  def change
+    update_view :submission_by_services, version: 3, revert_to_version: 2
+  end
+end

--- a/db/views/submission_by_services_v03.sql
+++ b/db/views/submission_by_services_v03.sql
@@ -1,0 +1,8 @@
+SELECT
+  COALESCE((app_ver.application ->> 'service_type')::text, 'not_found') AS service_type,
+  DATE_TRUNC('DAY', app.created_at) date_submitted
+FROM application AS app
+JOIN application_version AS app_ver
+  ON app.id = app_ver.application_id AND app_ver.version = 1
+WHERE app.application_type = 'crm4'
+GROUP BY service_type, date_submitted


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2194)

## Notes for reviewer
Return the Service Type column as text instead of JSON representation to avoid unnecessary speech marks