### PR TITLE
CRM457-2216: Fix bug in sorting by risk level

### DIFF
--- a/app/services/submissions/search_service.rb
+++ b/app/services/submissions/search_service.rb
@@ -106,7 +106,7 @@ module Submissions
       return "last_updated desc" unless search_params[:sort_by]
       raise "Unsortable column \"#{sort_by}\" supplied as sort_by argument" unless SORTABLE_COLUMNS.include?(sort_by.downcase)
 
-      if sort_by == "last_updated"
+      if sort_by.in?(%w[last_updated risk_level])
         "#{sort_by} #{sort_direction}"
       else
         "LOWER(#{sort_by}) #{sort_direction}"

--- a/spec/requests/submissions_search_spec.rb
+++ b/spec/requests/submissions_search_spec.rb
@@ -537,6 +537,7 @@ RSpec.describe "Submission search" do
         # create in order that will not return succcess without sorting
         travel_to(2.days.ago) do
           create(:submission, :with_pa_version,
+                 application_risk: "high",
                  laa_reference: "LAA-BBBBBB",
                  firm_name: "Aardvark & Co",
                  defendant_name: "Billy Bob",
@@ -545,6 +546,7 @@ RSpec.describe "Submission search" do
 
         travel_to(1.day.ago) do
           create(:submission, :with_pa_version,
+                 application_risk: "medium",
                  laa_reference: "LAA-CCCCCC",
                  firm_name: "Bob & Sons",
                  defendant_name: "Dilly Dodger",
@@ -553,6 +555,7 @@ RSpec.describe "Submission search" do
 
         travel_to(3.days.ago) do
           create(:submission, :with_pa_version,
+                 application_risk: "low",
                  laa_reference: "LAA-AAAAAA",
                  firm_name: "Xena & Daughters",
                  defendant_name: "Zach Zeigler",
@@ -712,6 +715,16 @@ RSpec.describe "Submission search" do
         }
 
         expect(response.parsed_body["data"].pluck("laa_reference")).to match(%w[LAA-CCCCCC LAA-BBBBBB LAA-AAAAAA])
+      end
+
+      it "can be sorted by risk_level descending" do
+        post search_endpoint, params: {
+          sort_by: "risk_level",
+          sort_direction: "desc",
+          application_type: "crm4",
+        }
+
+        expect(response.parsed_body["data"].pluck("laa_reference")).to match(%w[LAA-BBBBBB LAA-CCCCCC LAA-AAAAAA])
       end
 
       it "sorts raw data to match the order of data" do


### PR DESCRIPTION
## Description of change
The 'your claims' view in caseworker allows sorting by risk, so search now supports it. Except that it was broken because risk_level is an integer in the view, and we were calling "LOWER" on it

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2216)
