### PR TITLE
CRM457-2221: Allow providers to generate filtered lists

### DIFF
--- a/app/controllers/V1/submissions/searches_controller.rb
+++ b/app/controllers/V1/submissions/searches_controller.rb
@@ -30,6 +30,7 @@ module V1
           :status_with_assignment,
           :id_to_exclude,
           status_with_assignment: [],
+          account_number: [],
         )
       end
     end

--- a/app/services/authorization/rules.rb
+++ b/app/services/authorization/rules.rb
@@ -12,12 +12,11 @@ module Authorization
           create: ->(_, params) { params[:application_state].in?(PERMITTED_INITIAL_SUBMISSION_STATES) },
           update: ->(object, params) { state_pair_allowed?(object, params, PERMITTED_SUBMISSION_STATE_CHANGES[:provider]) },
         },
+        searches: {
+          create: true,
+        },
       },
       caseworker: {
-        subscribers: {
-          create: true,
-          destroy: ->(object, _) { !object || object.subscriber_type == "caseworker" },
-        },
         submissions: {
           index: true,
           show: true,

--- a/app/services/submissions/search_service.rb
+++ b/app/services/submissions/search_service.rb
@@ -1,6 +1,17 @@
 module Submissions
   class SearchService
-    SORTABLE_COLUMNS = %w[laa_reference firm_name client_name last_updated status_with_assignment risk_level service_name].freeze
+    SORTABLE_COLUMNS = %w[
+      ufn
+      laa_reference
+      firm_name
+      client_name
+      last_updated
+      status_with_assignment
+      risk_level
+      service_name
+      account_number
+      last_state_change
+    ].freeze
 
     attr_reader :search_params
 
@@ -106,7 +117,7 @@ module Submissions
       return "last_updated desc" unless search_params[:sort_by]
       raise "Unsortable column \"#{sort_by}\" supplied as sort_by argument" unless SORTABLE_COLUMNS.include?(sort_by.downcase)
 
-      if sort_by.in?(%w[last_updated risk_level])
+      if sort_by.in?(%w[last_updated risk_level last_state_change])
         "#{sort_by} #{sort_direction}"
       else
         "LOWER(#{sort_by}) #{sort_direction}"

--- a/db/migrate/20241125171006_update_searches_to_version_7.rb
+++ b/db/migrate/20241125171006_update_searches_to_version_7.rb
@@ -1,0 +1,5 @@
+class UpdateSearchesToVersion7 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :searches, version: 7, revert_to_version: 6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_15_101721) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_25_171006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -198,10 +198,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_15_101721) do
           )
    SELECT app.id,
       app_ver.id AS application_version_id,
+      (app_ver.application ->> 'ufn'::text) AS ufn,
       (app_ver.application ->> 'laa_reference'::text) AS laa_reference,
       ((app_ver.application -> 'firm_office'::text) ->> 'name'::text) AS firm_name,
       ((app_ver.application -> 'firm_office'::text) ->> 'account_number'::text) AS account_number,
       (app_ver.application ->> 'service_name'::text) AS service_name,
+      app_ver.created_at AS last_state_change,
           CASE app.application_risk
               WHEN 'high'::text THEN 3
               WHEN 'medium'::text THEN 2

--- a/db/views/searches_v07.sql
+++ b/db/views/searches_v07.sql
@@ -1,0 +1,46 @@
+WITH defendants AS (
+  SELECT
+    app.id,
+    CASE WHEN app.application_type = 'crm4' THEN
+        (app_ver.application -> 'defendant' ->> 'first_name') || ' ' || (app_ver.application -> 'defendant' ->> 'last_name')
+       ELSE
+        (
+          SELECT (defendants.value->>'first_name') || ' ' || (defendants.value->>'last_name')
+          FROM jsonb_array_elements(app_ver.application->'defendants') AS defendants
+          WHERE defendants.value->>'main' = 'true'
+        )
+       END AS client_name
+  FROM application AS app
+    JOIN application_version AS app_ver
+      ON app.id = app_ver.application_id AND app.current_version = app_ver.version
+)
+SELECT
+  app.id,
+  app_ver.id as application_version_id,
+  app_ver.application ->> 'ufn' as ufn,
+  app_ver.application ->> 'laa_reference' as laa_reference,
+  app_ver.application -> 'firm_office' ->> 'name' as firm_name,
+  app_ver.application -> 'firm_office' ->> 'account_number' as account_number,
+  app_ver.application ->> 'service_name' as service_name,
+  app_ver.created_at as last_state_change,
+  CASE app.application_risk
+  WHEN 'high' THEN 3
+  WHEN 'medium' THEN 2
+  ELSE 1 END as risk_level,
+  def.client_name,
+  app_ver.search_fields,
+  app.has_been_assigned_to,
+  app.assigned_user_id,
+  app.created_at as date_submitted,
+  app.last_updated_at as last_updated, -- latest event's created_at date in most instances
+  CASE WHEN app.state = 'submitted' AND app.assigned_user_id IS NOT NULL THEN 'in_progress'
+       WHEN app.state = 'submitted' AND app.assigned_user_id IS NULL THEN 'not_assigned'
+       ELSE app.state
+       END AS status_with_assignment,
+  app.application_type as application_type,
+  app.application_risk as risk
+FROM application AS app
+JOIN application_version AS app_ver
+  ON app.id = app_ver.application_id AND app.current_version = app_ver.version
+JOIN defendants AS def
+    ON def.id = app.id

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -114,26 +114,9 @@ RSpec.describe "Authorization" do
     it_behaves_like "subscriber and unsubscriber" do
       let(:role) { :provider }
     end
-
-    context "when searching" do
-      before do
-        allow(Tokens::VerificationService)
-          .to receive(:call)
-          .and_return(valid: true, role: :provider)
-      end
-
-      it "does not allow searches" do
-        post "/v1/submissions/searches"
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
   end
 
   context "with caseworker app" do
-    it_behaves_like "subscriber and unsubscriber" do
-      let(:role) { :caseworker }
-    end
-
     context "when searching" do
       before do
         allow(Tokens::VerificationService)

--- a/spec/requests/submissions_search_spec.rb
+++ b/spec/requests/submissions_search_spec.rb
@@ -428,6 +428,15 @@ RSpec.describe "Submission search" do
         expect(response.parsed_body["raw_data"].size).to eq 1
         expect(response.parsed_body["raw_data"].pluck("application").pluck("ufn")).to eq(["111111/111"])
       end
+
+      it "accepts arrays" do
+        post search_endpoint, params: {
+          application_type: "crm4",
+          account_number: %w[ABC123 DEF456],
+        }
+
+        expect(response.parsed_body["raw_data"].size).to eq 2
+      end
     end
 
     context "with id_to_exclude filter" do


### PR DESCRIPTION
## Description of change
- Providers can access the search endpoint
- The search endpoint allows passing in multiple office codes
- Searches can be sorted by UFN
- Searches can be sorted by the date of the most recent state change (e.g. for submitted applications it's when they were submitted, not the date of the most recent caseworker assignment)
- Caseworker app can no longer subscribe/unsubscribe (since it doesn't do that any more)


[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2221)
