### PR TITLE
CRM457-2322 part 1: Pull anonymised records from prod to localhost

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "bootsnap", require: false
 gem "govuk_notify_rails", "~> 3.0.0"
 gem "httparty"
 gem "jwt", "~> 2.9.3"
-gem "laa_crime_forms_common", "~> 0.5.5", github: "ministryofjustice/laa-crime-forms-common"
+gem "laa_crime_forms_common", "~> 0.6.0", github: "ministryofjustice/laa-crime-forms-common"
 gem "lograge"
 gem "logstash-event"
 gem "oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-crime-forms-common.git
-  revision: a43e6909376cc954a27a6f26f766e96f0610e760
+  revision: f09854276e569431b4dd6047c4ca0a4002d8fbf7
   specs:
-    laa_crime_forms_common (0.5.5)
+    laa_crime_forms_common (0.6.0)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)
@@ -404,7 +404,7 @@ DEPENDENCIES
   govuk_notify_rails (~> 3.0.0)
   httparty
   jwt (~> 2.9.3)
-  laa_crime_forms_common (~> 0.5.5)!
+  laa_crime_forms_common (~> 0.6.0)!
   lograge
   logstash-event
   oauth2

--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ We have a default [k8s security context ](https://kubernetes.io/docs/reference/g
 - seccompProfile.type - The Secure Computing Mode (Linux kernel feature that limits syscalls that processes can run) options to use by this container. Currenly defaults to RuntimeDefault which is the [widely accepted default profile](https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile)
 - capabilities - The POSIX capabilities to add/drop when running containers. Currently defaults to drop["ALL"] which means all of these capabilities will be dropped - since this doesn't cause any issues, it's best to keep as is for security reasons until there's a need for change
 
+## Debugging production data
+We are often asked to investigate the state of records in our production environment. To
+make it safer to explore, we have a script that pulls an anonymised version (all PII removed) of a record
+to a local DB. To use it, run the following:
+
+```
+./bin/download_anonymised LAA-REFERENCE
+```
+
+You can then either open up the rails console (`bundle exec rails c`) to explore the data that way,
+or load up the rails server (`bundle exec rails s -p 3003`) and point your local caseworker app
+at it to see the record in the UI.
+
+When you are done, clear the record entirely with:
+
+```
+./bin/delete_anonymised LAA-REFERENCE
+```
+
 ## Licence
 
 This project is licensed under the [MIT License][mit].

--- a/bin/delete_anonymised
+++ b/bin/delete_anonymised
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+LAA_REF=$1
+
+bundle exec rails anonymised:delete\[$LAA_REF\]

--- a/bin/download_anonymised
+++ b/bin/download_anonymised
@@ -1,11 +1,14 @@
 #!/bin/sh
+set -e
 
 LAA_REF=$1
 
-kubectl exec deploy/laa-crime-application-store-app \
+echo "Downloading anonymised record..."
+OUTPUT=$(kubectl exec deploy/laa-crime-application-store-app \
 -it -n laa-crime-application-store-production -- \
-bundle exec rails anonymised:download\[$LAA_REF\] > temp-anonymised.txt
+bundle exec rails anonymised:download\[$LAA_REF\])
 
-bundle exec rails anonymised:import\[temp-anonymised.txt\]
+echo "Importing anonymised record..."
+ANONYMISED_DOWNLOAD_OUTPUT=$OUTPUT bundle exec rails anonymised:import\[ANONYMISED_DOWNLOAD_OUTPUT\]
 
-rm temp-anonymised.txt
+echo "Done."

--- a/bin/download_anonymised
+++ b/bin/download_anonymised
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+LAA_REF=$1
+
+kubectl exec deploy/laa-crime-application-store-app \
+-it -n laa-crime-application-store-production -- \
+bundle exec rails anonymised:download\[$LAA_REF\] > temp-anonymised.txt
+
+bundle exec rails anonymised:import\[temp-anonymised.txt\]
+
+rm temp-anonymised.txt

--- a/lib/tasks/anonymised.rake
+++ b/lib/tasks/anonymised.rake
@@ -14,9 +14,9 @@ namespace :anonymised do
     puts "JSONEND"
   end
 
-  desc "Import a submission from a text file containing JSON"
-  task :import, [:file_name] => :environment do |_, args|
-    data = File.read(args[:file_name])
+  desc "Import a submission from a named env var"
+  task :import, [:env_var] => :environment do |_, args|
+    data = ENV[args[:env_var]]
     json = data.split("JSONSTART").last.split("JSONEND").first
     content = JSON.parse(json)
     Submission.transaction do

--- a/lib/tasks/anonymised.rake
+++ b/lib/tasks/anonymised.rake
@@ -1,0 +1,50 @@
+namespace :anonymised do
+  desc "Print an anonymised version of the payload"
+  task :download, [:laa_reference] => :environment do |_, args|
+    submission = Submission.joins(:ordered_submission_versions)
+                           .find_by("application_version.application->>'laa_reference' = ?",
+                                    args[:laa_reference])
+    service_type = submission.application_type == 'crm7' ? :nsm : :prior_authority
+    anonymised = LaaCrimeFormsCommon::Anonymiser.anonymise(
+      service_type,
+      submission.latest_version.application
+    )
+    puts "JSONSTART"
+    puts submission.as_json.merge(application: anonymised).to_json
+    puts "JSONEND"
+  end
+
+  desc "Import a submission from a text file containing JSON"
+  task :import, [:file_name] => :environment do |_, args|
+    data = File.read(args[:file_name])
+    json = data.split("JSONSTART").last.split("JSONEND").first
+    content = JSON.parse(json)
+    Submission.transaction do
+      submission = Submission.create!(
+        content.slice(
+          *%w[application_risk application_type updated_at created_at last_updated_at assigned_user_id events]
+        ).merge(
+          id: content["application_id"],
+          state: content["application_state"],
+          current_version: content["version"],
+        )
+      )
+
+      submission.ordered_submission_versions.create!(
+        json_schema_version: content["json_schema_version"],
+        application: content["application"],
+        version: content["version"],
+      )
+    end
+  end
+
+  desc "Delete a submission based on its LAA reference"
+  task :delete, [:laa_reference] => :environment do |_, args|
+    raise "Cannot delete in a production environment" if Rails.env.production?
+
+    submission = Submission.joins(:ordered_submission_versions)
+                           .find_by("application_version.application->>'laa_reference' = ?",
+                                    args[:laa_reference])
+    submission.destroy!
+  end
+end

--- a/spec/lib/tasks/anonymised_data_spec.rb
+++ b/spec/lib/tasks/anonymised_data_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.describe "anonymised:" do
+  let(:arbitrary_fixed_date) { Date.new(2024, 11, 1) }
+  let(:anonymised_nsm_payload) do
+    {
+      application_risk: "low",
+      application_type: "crm7",
+      updated_at: "2024-11-01T00:00:00.000Z",
+      created_at: "2024-11-01T00:00:00.000Z",
+      last_updated_at: "2024-11-01T00:00:00.000Z",
+      assigned_user_id: nil,
+      application_state: "submitted",
+      version: 1,
+      json_schema_version: 1,
+      application: {
+        ufn: "010124/001",
+        status: "submitted",
+        solicitor: nil,
+        court_type: "other",
+        created_at: "2024-10-31T23:50:00.000Z",
+        defendants: [
+          {
+            main: true,
+            last_name: "ANONYMISED",
+            first_name: "ANONYMISED",
+          },
+        ],
+        updated_at: "2024-11-01T00:00:00.000Z",
+        firm_office: {
+          name: nil,
+          town: "Lawyer Town",
+          postcode: "CR0 1RE",
+          previous_id: nil,
+          account_number: "1A123B",
+          address_line_1: "2 Laywer Suite",
+          address_line_2: nil,
+          vat_registered: "yes",
+        },
+        office_code: "1A123B",
+        service_type: "other",
+        laa_reference: "LAA-123456",
+      },
+      events: [],
+      application_id: submission_id,
+    }
+  end
+  let(:anonymised_pa_payload) do
+    {
+      application_risk: "low",
+      application_type: "crm4",
+      updated_at: "2024-11-01T00:00:00.000Z",
+      created_at: "2024-11-01T00:00:00.000Z",
+      last_updated_at: "2024-11-01T00:00:00.000Z",
+      assigned_user_id: nil,
+      application_state: "submitted",
+      version: 1,
+      json_schema_version: 1,
+      application: {
+        ufn: "010124/001",
+        status: "submitted",
+        defendant: {
+          last_name: "ANONYMISED",
+          first_name: "ANONYMISED",
+        },
+        solicitor: nil,
+        court_type: "other",
+        created_at: "2024-10-31T23:50:00.000Z",
+        updated_at: "2024-11-01T00:00:00.000Z",
+        firm_office: {
+          name: nil,
+          town: "Lawyer Town",
+          postcode: "CR0 1RE",
+          previous_id: nil,
+          account_number: "1A123B",
+          address_line_1: "2 Laywer Suite",
+          address_line_2: nil,
+          vat_registered: "yes",
+        },
+        office_code: "1A123B",
+        service_type: "ae_consultant",
+        laa_reference: "LAA-123456",
+      },
+      events: [],
+      application_id: submission_id,
+    }
+  end
+  let(:download_output) { "JSONSTART\n#{output_payload.to_json}\nJSONEND\n" }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    travel_to arbitrary_fixed_date
+  end
+
+  describe "download" do
+    subject(:download) { Rake::Task["anonymised:download"].execute(arguments) }
+
+    let(:arguments) { { laa_reference: } }
+    let(:laa_reference) { "LAA-123456" }
+    let(:submission_id) { submission.id }
+
+    before do
+      submission
+      allow($stdout).to receive(:puts)
+    end
+
+    after { Rake::Task["anonymised:download"].reenable }
+
+    context "when the submission is PA" do
+      let(:submission) { create :submission, :with_pa_version, laa_reference: }
+      let(:output_payload) { anonymised_pa_payload }
+
+      it "downloads an anonymised version of the record" do
+        expect { download }.to output(download_output).to_stdout
+      end
+    end
+
+    context "when the submission is CRM7" do
+      let(:submission) { create :submission, :with_nsm_version, laa_reference: }
+      let(:output_payload) { anonymised_nsm_payload }
+
+      it "downloads an anonymised version of the record" do
+        expect { download }.to output(download_output).to_stdout
+      end
+    end
+  end
+
+  describe "import" do
+    subject(:import) { Rake::Task["anonymised:import"].execute(arguments) }
+
+    let(:arguments) { { file_name: } }
+    let(:file_name) { "temp.txt" }
+    let(:submission_id) { SecureRandom.uuid }
+
+    before do
+      allow(File).to receive(:read).with(file_name).and_return(download_output)
+    end
+
+    after { Rake::Task["anonymised:download"].reenable }
+
+    context "when the submission is PA" do
+      let(:output_payload) { anonymised_pa_payload }
+
+      it "creates a local record" do
+        import
+        imported = Submission.find(submission_id)
+        expect(imported.application_type).to eq "crm4"
+        expect(imported.latest_version.application).to eq anonymised_pa_payload[:application].deep_stringify_keys
+      end
+    end
+
+    context "when the submission is NSM" do
+      let(:output_payload) { anonymised_nsm_payload }
+
+      it "creates a local record" do
+        import
+        imported = Submission.find(submission_id)
+        expect(imported.application_type).to eq "crm7"
+        expect(imported.latest_version.application).to eq anonymised_nsm_payload[:application].deep_stringify_keys
+      end
+    end
+  end
+
+  describe "delete" do
+    subject(:delete) { Rake::Task["anonymised:delete"].execute(arguments) }
+
+    let(:arguments) { { laa_reference: } }
+    let(:laa_reference) { "LAA-123456" }
+    let(:submission) { create :submission, :with_pa_version, laa_reference: }
+
+    before do
+      submission
+    end
+
+    it "deletes the submission" do
+      delete
+      expect(Submission.find_by(id: submission.id)).to be_nil
+    end
+
+    context "when in production" do
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it "raises and error" do
+        expect { delete }.to raise_error "Cannot delete in a production environment"
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/anonymised_data_spec.rb
+++ b/spec/lib/tasks/anonymised_data_spec.rb
@@ -128,12 +128,12 @@ RSpec.describe "anonymised:" do
   describe "import" do
     subject(:import) { Rake::Task["anonymised:import"].execute(arguments) }
 
-    let(:arguments) { { file_name: } }
-    let(:file_name) { "temp.txt" }
+    let(:arguments) { { env_var: } }
+    let(:env_var) { "DATA" }
     let(:submission_id) { SecureRandom.uuid }
 
     before do
-      allow(File).to receive(:read).with(file_name).and_return(download_output)
+      allow(ENV).to receive(:[]).with(env_var).and_return(download_output)
     end
 
     after { Rake::Task["anonymised:download"].reenable }


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2322)

Note that this is a first step towards pulling records from prod into a secure pre-prod environment, but it delivers incremental usefulness as a standalone step.
