### PR TITLE
CRM457-2335: Risk and value setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,7 @@ gem "bootsnap", require: false
 gem "govuk_notify_rails", "~> 3.0.0"
 gem "httparty"
 gem "jwt", "~> 2.9.3"
-# TODO: Remove ref when gem PR merged
-gem "laa_crime_forms_common", "~> 0.7.0", github: "ministryofjustice/laa-crime-forms-common", ref: "952e785"
+gem "laa_crime_forms_common", "~> 0.7.0", github: "ministryofjustice/laa-crime-forms-common"
 gem "lograge"
 gem "logstash-event"
 gem "oauth2"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,8 @@ gem "bootsnap", require: false
 gem "govuk_notify_rails", "~> 3.0.0"
 gem "httparty"
 gem "jwt", "~> 2.9.3"
-gem "laa_crime_forms_common", "~> 0.6.1", github: "ministryofjustice/laa-crime-forms-common"
+# TODO: Remove ref when gem PR merged
+gem "laa_crime_forms_common", "~> 0.7.0", github: "ministryofjustice/laa-crime-forms-common", ref: "952e785"
 gem "lograge"
 gem "logstash-event"
 gem "oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-crime-forms-common.git
-  revision: 46b03737d347cb0f2250de591670e1854add5696
+  revision: 952e78531b740c20570c888939e8a3c5cf02ab9c
+  ref: 952e785
   specs:
-    laa_crime_forms_common (0.6.1)
+    laa_crime_forms_common (0.7.0)
       httparty (>= 0.22.0, < 1)
       i18n (>= 1.8.11, < 2)
       json-schema (>= 5.0.0, < 6)
@@ -405,7 +406,7 @@ DEPENDENCIES
   govuk_notify_rails (~> 3.0.0)
   httparty
   jwt (~> 2.9.3)
-  laa_crime_forms_common (~> 0.6.1)!
+  laa_crime_forms_common (~> 0.7.0)!
   lograge
   logstash-event
   oauth2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-crime-forms-common.git
-  revision: 952e78531b740c20570c888939e8a3c5cf02ab9c
-  ref: 952e785
+  revision: 3362cd150350ac344413f329a85d3ca811de7944
   specs:
     laa_crime_forms_common (0.7.0)
       httparty (>= 0.22.0, < 1)

--- a/app/controllers/V1/submissions/searches_controller.rb
+++ b/app/controllers/V1/submissions/searches_controller.rb
@@ -2,7 +2,7 @@ module V1
   module Submissions
     class SearchesController < ApplicationController
       def create
-        @results = ::Submissions::SearchService.call(search_params)
+        @results = ::Submissions::SearchService.call(search_params, current_client_role)
 
         render json: @results, status: :created
       rescue StandardError => e

--- a/app/controllers/V1/submissions_controller.rb
+++ b/app/controllers/V1/submissions_controller.rb
@@ -6,7 +6,7 @@ module V1
     end
 
     def show
-      render json: current_submission
+      render json: current_submission.as_json(client_role: current_client_role)
     end
 
     def create

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,7 +9,6 @@ class Submission < ApplicationRecord
 
   validates :state, presence: true
   validates :application_type, presence: true
-  validates :application_risk, presence: true
 
   def latest_version
     ordered_submission_versions.first

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -10,15 +10,16 @@ class Submission < ApplicationRecord
   validates :state, presence: true
   validates :application_type, presence: true
 
-  def latest_version
-    ordered_submission_versions.first
+  def latest_version(include_pending: true)
+    ordered_submission_versions.then { include_pending ? _1 : _1.where(pending: false) }.first
   end
 
-  def as_json(*)
+  def as_json(args = {})
+    version = latest_version(include_pending: args[:client_role] == :caseworker)
     super(only: %i[application_risk application_type updated_at created_at last_updated_at assigned_user_id]).merge(
       application_state: state,
       version: current_version,
-      json_schema_version: latest_version.json_schema_version,
-    ).merge(application: latest_version.application, events:, application_id: id)
+      json_schema_version: version.json_schema_version,
+    ).merge(application: version.application, events:, application_id: id)
   end
 end

--- a/app/services/submissions/search_service.rb
+++ b/app/services/submissions/search_service.rb
@@ -13,14 +13,15 @@ module Submissions
       last_state_change
     ].freeze
 
-    attr_reader :search_params
+    attr_reader :search_params, :client_role
 
-    def initialize(search_params)
+    def initialize(search_params, client_role)
       @search_params = search_params
+      @client_role = client_role
     end
 
-    def self.call(search_params)
-      new(search_params).call
+    def self.call(search_params, client_role)
+      new(search_params, client_role).call
     end
 
     def call
@@ -64,9 +65,9 @@ module Submissions
       # order they were in from the "data".
       ids = @data.limit(limit).offset(offset).pluck(:id)
 
-      Submission.find(ids).sort_by do |submission|
-        ids.index(submission.id)
-      end
+      Submission.find(ids)
+                .sort_by { ids.index(_1.id) }
+                .map { _1.as_json(client_role:) }
     end
 
     def application_type

--- a/db/migrate/20241211102459_make_risk_optional.rb
+++ b/db/migrate/20241211102459_make_risk_optional.rb
@@ -1,0 +1,7 @@
+class MakeRiskOptional < ActiveRecord::Migration[8.0]
+  def change
+    drop_view :searches, revert_to_version: 7
+    change_column :application, :application_risk, :string, null: true
+    create_view :searches, version: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_06_171615) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_11_102459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_06_171615) do
   create_table "application", id: :uuid, default: nil, force: :cascade do |t|
     t.integer "current_version", null: false
     t.text "state", null: false
-    t.text "application_risk", null: false
+    t.text "application_risk"
     t.text "application_type", null: false
     t.datetime "updated_at", precision: nil
     t.jsonb "events"

--- a/spec/requests/create_submission_spec.rb
+++ b/spec/requests/create_submission_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Create submission" do
         application_id: id,
         application_type: "crm4",
         application_state: "submitted",
-        application_risk: "low",
+        application_risk: nil,
         json_schema_version: 1,
         application: { foo: :bar },
       }
@@ -22,7 +22,7 @@ RSpec.describe "Create submission" do
         id:,
         state: "submitted",
         application_type: "crm4",
-        application_risk: "low",
+        application_risk: nil,
         current_version: 1,
         last_updated_at: created_record.created_at,
       )
@@ -100,6 +100,31 @@ RSpec.describe "Create submission" do
         application_state: "submitted",
       }
       expect(response).to have_http_status :conflict
+    end
+
+    it "sets risk and value if appropriate" do
+      id = SecureRandom.uuid
+      post "/v1/submissions", headers: { "Content-Type" => "application/json" }, params: {
+        application_id: id,
+        application_type: "crm7",
+        application_state: "submitted",
+        application_risk: nil,
+        json_schema_version: 1,
+        application: {
+          claim_type: "non_standard_magistrate",
+          rep_order_date: "2024-1-1",
+          reasons_for_claim: %w[other],
+          work_items: [],
+          letters_and_calls: [],
+          disbursements: [],
+        },
+      }.to_json
+      expect(response).to have_http_status :created
+
+      expect(created_record).to have_attributes(
+        application_risk: "low",
+      )
+      expect(created_record.latest_version.application.dig("cost_summary", "high_value")).to be false
     end
 
     context "when the gem hook dictates a state change" do

--- a/spec/requests/show_submission_spec.rb
+++ b/spec/requests/show_submission_spec.rb
@@ -1,22 +1,34 @@
 require "rails_helper"
 
 RSpec.describe "Show submission" do
-  before { allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role: :provider) }
+  before do
+    allow(Tokens::VerificationService).to receive(:call).and_return(valid: true, role:)
+    create(:submission_version, submission:, version: 1, application: { old: :data })
+    create(:submission_version, submission:, version: 2, application: { new: :data })
+    create(:submission_version, submission:, version: 3, application: { pending: :data }, pending: true)
+  end
+
+  let(:role) { :provider }
+  let(:submission) { create :submission, current_version: 2 }
 
   it "returns a submission" do
-    submission = create(:submission)
     get "/v1/submissions/#{submission.id}"
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body["application_id"]).to eq submission.id
   end
 
-  it "returns the latest version" do
-    submission = create(:submission, current_version: 2)
-    create(:submission_version, submission:, version: 1, application: { old: :data })
-    create(:submission_version, submission:, version: 2, application: { new: :data })
-
+  it "returns the latest non-pending version" do
     get "/v1/submissions/#{submission.id}"
 
     expect(response.parsed_body["application"]).to eq({ "new" => "data" })
+  end
+
+  context "when viewer is a caseworker" do
+    let(:role) { :caseworker }
+
+    it "returns the latest version even if it's pending" do
+      get "/v1/submissions/#{submission.id}"
+      expect(response.parsed_body["application"]).to eq({ "pending" => "data" })
+    end
   end
 end

--- a/spec/requests/update_submission_metadata_spec.rb
+++ b/spec/requests/update_submission_metadata_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "Update submission metadata" do
 
     it "validates" do
       submission = create(:submission, application_risk: "low")
-      patch "/v1/submissions/#{submission.id}/metadata", params: { application_risk: nil }
+      allow(Submissions::MetadataUpdateService).to receive(:call).and_raise(ActiveRecord::RecordInvalid)
+      patch "/v1/submissions/#{submission.id}/metadata", params: { application_risk: "high" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(submission.application_risk).to eq("low")
     end

--- a/spec/services/submissions/search_service_spec.rb
+++ b/spec/services/submissions/search_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Submissions::SearchService do
   end
 
   describe "#call" do
-    subject(:call) { described_class.new(params).call }
+    subject(:call) { described_class.new(params, :caseworker).call }
 
     it "returns JSON string" do
       expect(call).to be_a(String)
@@ -32,7 +32,7 @@ RSpec.describe Submissions::SearchService do
   end
 
   describe ".call" do
-    subject(:call) { described_class.call(params) }
+    subject(:call) { described_class.call(params, :caseworker) }
 
     it "returns JSON of expected structure" do
       expect(JSON.parse(call)).to match(expected_result_as_hash)


### PR DESCRIPTION
## Description of change
Allow the gem to handle setting risk and high_value flags

Bonus: Ensure that the provider app never sees work-in-progress adjustments by a caseworker (I don't think this is a bug at the moment, but we're relying on the provider app _hiding_ these adjustments, which it shouldn't have to do)

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2335)
