### PR TITLE
Get schema file under control

### DIFF
--- a/config/initializers/schema_fix.rb
+++ b/config/initializers/schema_fix.rb
@@ -1,0 +1,10 @@
+
+# ActiveRecord doesn't know how to handle postgis interna tables properly, and will by default
+# include them in the schema file, which means it will then try to _delete_ them when doing
+# rails db:prepare, which will then blow up.
+
+# The correct way to deal with this is to install activerecord-postgis-adapter and update
+# the adaptor in database.yml to "postgis". However, that gem doesn't yet work with Rails 8,
+# so until that is fixed (https://github.com/rgeo/activerecord-postgis-adapter/pull/419),
+# we can work around it by telling ActiveRecord to ignore postgis tables as follows:
+ActiveRecord::SchemaDumper.ignore_tables = ["spatial_ref_sys", "geometry_columns", "geography_columns"]


### PR DESCRIPTION
## Description of change
If you've run `rails db:migrate` recently you'll see that the schema file gets messed up by including a bunch of postgis tables, which then cause tasks like `rails db:prepare` to explode. As a result, the schema file has been getting rather out of date. So I've:

- Added a workaround for the postgis issue and a comment explaining how/when it can be resolved properly
- Run the migrations from scratch on a clean database so that the schema file accurately represents what should currently be in production

This should mean that future migrations should only change the schema file in the normal ways.
