### PR TITLE
CRM457-2347: Correct the mailer to always send `to` as an array

### DIFF
--- a/app/mailers/email_to_provider_mailer.rb
+++ b/app/mailers/email_to_provider_mailer.rb
@@ -5,7 +5,7 @@ class EmailToProviderMailer < GovukNotifyRails::Mailer
       message = message_class.new(submission.latest_version.application)
       set_template(message.template)
       set_personalisation(**message.contents)
-      mail(to: message.recipient)
+      mail(to: Array(message.recipient))
     end
   end
   # :nocov:

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -1,2 +1,14 @@
 ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery,
-                                       api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY', nil)
+                                       api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY", nil)
+
+class MailDeliveryJobWrapper < ActionMailer::MailDeliveryJob
+  def serialize
+    super.tap do |args|
+      args["arguments"][3] = Array(args["arguments"][3])
+    end
+  end
+end
+
+# Set this so we ensure that the `to` list we pass to
+# govuk_notify_rails is always an array
+Rails.application.config.action_mailer.delivery_job = "MailDeliveryJobWrapper"

--- a/spec/jobs/mail_delivery_job_wrapper_spec.rb
+++ b/spec/jobs/mail_delivery_job_wrapper_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+# rubocop:disable Rails/ApplicationMailer, Rails/I18nLocaleTexts
+RSpec.describe MailDeliveryJobWrapper do
+  before do
+    ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery,
+                                           api_key: "fake-test-key"
+  end
+
+  it "ensures 'to' is always an array" do
+    mailer_class = Class.new(ActionMailer::Base) do
+      default delivery_method: :govuk_notify
+
+      def test_email
+        mail(
+          to: "invalid@email.",
+          subject: "Test",
+          body: "Test content",
+        )
+      end
+    end
+
+    mail = mailer_class.test_email
+    job = described_class.set(queue: :mailers).perform_later(
+      mailer_class.name,
+      "test_email",
+      "deliver_now",
+      mail.to,
+      {},
+    )
+
+    serialized_job = job.serialize
+    args = serialized_job["arguments"]
+    expect(args[3]).to be_an(Array)
+  end
+end
+# rubocop:enable Rails/ApplicationMailer, Rails/I18nLocaleTexts


### PR DESCRIPTION
## Description of change

Wrap the mailer to ensure that we always send `to` as an array even if it's invalid.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2347)