### PR TITLE
CRM457-2408: Increase db connection pool size from default (15) to 25

### DIFF
--- a/helm_deploy/templates/metabase/deployment.yaml
+++ b/helm_deploy/templates/metabase/deployment.yaml
@@ -54,4 +54,7 @@ spec:
           # This is how frequently users must re-authenticate (measured from last authentication, not last activity)
           - name: MAX_SESSION_AGE
             value: '1440'
+          # Maximum number of concurrent db connections on data sources
+          - name: MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE
+            value: '25'
 {{- end }}


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2408)

## Notes for reviewer
This is an attempt to fix issues with dashboards not loading, more information[ in this thread](https://mojdt.slack.com/archives/C05212WRK5J/p1737717395420209)
The error seems to be related to db connection pooling and could indicate that there are too many threads open on the connection for Metabase's JDBC to handle, so we're increasing the number of available threads on the JDBC. 

