### PR TITLE
Make pool size config per env

### DIFF
--- a/helm_deploy/templates/metabase/deployment.yaml
+++ b/helm_deploy/templates/metabase/deployment.yaml
@@ -56,5 +56,8 @@ spec:
             value: '1440'
           # Maximum number of concurrent db connections on data sources
           - name: MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE
-            value: '25'
+            value: {{ .Values.metabase.warehouseDbPoolSize }}
+          # Maximum number of concurrent db connections on application db
+          - name: MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE
+            value: {{ .Values.metabase.applicationeDbPoolSize }}
 {{- end }}

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -69,3 +69,5 @@ metabase:
     namespace: laa-crime-application-store-production
     tls:
       secretName: laa-crime-application-store-cert
+  warehouseDbPoolSize: 25
+  applicationDbPoolSize: 15

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -70,3 +70,5 @@ metabase:
     namespace: laa-crime-application-store-uat
     tls:
       secretName: laa-crime-application-store-cert
+  warehouseDbPoolSize: 30
+  applicationDbPoolSize: 30


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2408)

## Notes for reviewer

- Make pool size config environment specific 
- Add config for applicaiton db max pool size
- Set UAT to 30 max pool size for both warehouse and application dbs
- Set Production to same as previous (25 max pool size for warehouse, 15 (default) for application dbs