### PR TITLE
Update submission_creation_times to ignore assignment versions

### DIFF
--- a/db/migrate/20250514155430_update_submission_creation_times_to_version_3.rb
+++ b/db/migrate/20250514155430_update_submission_creation_times_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateSubmissionCreationTimesToVersion3 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :submission_creation_times, version: 3, revert_to_version: 2
+  end
+end

--- a/db/views/submission_creation_times_v03.sql
+++ b/db/views/submission_creation_times_v03.sql
@@ -1,0 +1,29 @@
+WITH
+  base AS (
+    SELECT DISTINCT
+    app_ver.application_id,
+    application.application_type,
+    (app_ver.application ->> 'created_at')::timestamp AS draft_created_date,
+    (app_ver.application ->> 'office_code')::text AS office_code,
+    application_submissions.submission_date AS submission_date,
+    CASE
+      WHEN (app_ver.application ->> 'import_date')::timestamp IS NOT NULL THEN true
+      ELSE false
+    END AS claim_imported
+  FROM application_version AS app_ver
+  -- get first submitted date (so that versions made from assignments not included)
+  INNER JOIN (
+    SELECT
+      application_id,
+      MIN(created_at) AS submission_date
+    FROM application_version
+    WHERE (application ->> 'status')::text = 'submitted'
+    GROUP BY application_id
+  ) AS application_submissions ON app_ver.application_id = application_submissions.application_id
+  INNER JOIN application ON app_ver.application_id = application.id
+  WHERE (app_ver.application ->> 'status')::text = 'submitted'
+)
+
+SELECT *,
+  EXTRACT(EPOCH FROM (submission_date - draft_created_date))/60 AS minutes_to_submit
+FROM base


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2455)

## Notes for reviewer
To fix erroneous records being added to view since a new version is created for each assignment
Only retrieves the first submitted version for a given application id 
[This rectifies issue found here
](https://mojdt.slack.com/archives/C034YPREUSF/p1747236841024359?thread_ts=1747213061.572249&cid=C034YPREUSF)