### PR TITLE
CRM456-2519: Create Metrics Report for Time To Assess A Claim

### DIFF
--- a/db/migrate/20250514090602_create_submission_assess_times.rb
+++ b/db/migrate/20250514090602_create_submission_assess_times.rb
@@ -1,0 +1,5 @@
+class CreateSubmissionAssessTimes < ActiveRecord::Migration[8.0]
+  def change
+    create_view :submission_assess_times
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_12_140556) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_14_155430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -222,16 +222,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_140556) do
   SQL
   create_view "submission_creation_times", sql_definition: <<-SQL
       WITH base AS (
-           SELECT app_ver.application_id,
+           SELECT DISTINCT app_ver.application_id,
               application.application_type,
               ((app_ver.application ->> 'created_at'::text))::timestamp without time zone AS draft_created_date,
               (app_ver.application ->> 'office_code'::text) AS office_code,
-              app_ver.created_at AS submission_date,
+              application_submissions.submission_date,
                   CASE
                       WHEN (((app_ver.application ->> 'import_date'::text))::timestamp without time zone IS NOT NULL) THEN true
                       ELSE false
                   END AS claim_imported
-             FROM (application_version app_ver
+             FROM ((application_version app_ver
+               JOIN ( SELECT application_version.application_id,
+                      min(application_version.created_at) AS submission_date
+                     FROM application_version
+                    WHERE ((application_version.application ->> 'status'::text) = 'submitted'::text)
+                    GROUP BY application_version.application_id) application_submissions ON ((app_ver.application_id = application_submissions.application_id)))
                JOIN application ON ((app_ver.application_id = application.id)))
             WHERE ((app_ver.application ->> 'status'::text) = 'submitted'::text)
           )
@@ -243,5 +248,42 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_140556) do
       base.claim_imported,
       (EXTRACT(epoch FROM (base.submission_date - base.draft_created_date)) / (60)::numeric) AS minutes_to_submit
      FROM base;
+  SQL
+  create_view "submission_assess_times", sql_definition: <<-SQL
+      WITH base AS (
+           SELECT application.id,
+              application.application_type,
+              application.created_at AS submission_date,
+              (first_decision.application ->> 'status'::text) AS first_decision,
+              (first_decision.application ->> 'office_code'::text) AS office_code,
+              first_decision.decision_created_at AS first_decision_date
+             FROM (application
+               JOIN ( SELECT application_version.application_id,
+                      application_version.application,
+                      min(application_version.created_at) AS decision_created_at
+                     FROM application_version
+                    GROUP BY application_version.application_id, application_version.application) first_decision ON ((application.id = first_decision.application_id)))
+            WHERE ((first_decision.application ->> 'status'::text) = ANY (ARRAY['rejected'::text, 'part_grant'::text, 'granted'::text]))
+          ), assignment_events AS (
+           SELECT application.id,
+              ((events.value ->> 'created_at'::text))::timestamp without time zone AS assigned_at
+             FROM (application
+               CROSS JOIN LATERAL jsonb_array_elements(application.caseworker_history_events) events(value))
+            WHERE ((events.value ->> 'event_type'::text) = 'assignment'::text)
+          )
+   SELECT base.id,
+      base.application_type,
+      base.submission_date,
+      base.office_code,
+      base.first_decision,
+      base.first_decision_date,
+      first_assignment.first_assigned_date,
+      (EXTRACT(epoch FROM (first_assignment.first_assigned_date - base.submission_date)) / (60)::numeric) AS minutes_to_assign,
+      (EXTRACT(epoch FROM (base.first_decision_date - first_assignment.first_assigned_date)) / (60)::numeric) AS minutes_to_assess
+     FROM (base
+       JOIN ( SELECT assignment_events.id,
+              min(assignment_events.assigned_at) AS first_assigned_date
+             FROM assignment_events
+            GROUP BY assignment_events.id) first_assignment ON ((base.id = first_assignment.id)));
   SQL
 end

--- a/db/views/submission_assess_times_v01.sql
+++ b/db/views/submission_assess_times_v01.sql
@@ -4,18 +4,16 @@ WITH
     application.id,
     application.application_type,
     application.created_at AS submission_date,
-    application.state AS decision,
-    (app_ver.application ->> 'office_code')::text AS office_code,
-    (app_ver.created_at)::timestamp AS decision_date
-    FROM application_version AS app_ver
-    INNER JOIN application ON app_ver.application_id = application.id
+    (first_decision.application ->> 'status')::text AS first_decision,
+    (first_decision.application ->> 'office_code')::text AS office_code,
+    first_decision.decision_created_at AS first_decision_date
+    FROM application
     INNER JOIN (
-      SELECT application_id, MAX(created_at) AS max_created_at
+      SELECT application_id, application, MIN(created_at) AS decision_created_at
       FROM application_version
-      GROUP BY application_id
-    )  AS latest_decision ON app_ver.application_id = latest_decision.application_id
-                          AND  app_ver.created_at = latest_decision.max_created_at
-    WHERE (app_ver.application ->> 'status')::text IN ('rejected', 'part_grant', 'granted')
+      GROUP BY application_id, application
+    )  AS first_decision ON application.id = first_decision.application_id
+    WHERE (first_decision.application ->> 'status')::text IN ('rejected', 'part_grant', 'granted')
   ),
   assignment_events AS (
     SELECT
@@ -26,6 +24,19 @@ WITH
     WHERE events ->> 'event_type' = 'assignment'
   )
 
-SELECT *,
-  EXTRACT(EPOCH FROM (decision_date - submission_date))/60 AS minutes_to_assess
+SELECT
+	base.id,
+	base.application_type,
+	base.submission_date,
+	base.office_code,
+	first_decision,
+	first_decision_date,
+	first_assigned_date,
+	EXTRACT(EPOCH FROM (first_assigned_date - submission_date))/60 AS minutes_to_assign,
+	EXTRACT(EPOCH FROM (first_decision_date - first_assigned_date))/60 AS minutes_to_assess
 FROM base
+INNER JOIN (
+  SELECT id, MIN(assigned_at) AS first_assigned_date
+  FROM assignment_events
+  GROUP BY id
+) AS first_assignment ON base.id = first_assignment.id

--- a/db/views/submission_assess_times_v01.sql
+++ b/db/views/submission_assess_times_v01.sql
@@ -1,0 +1,31 @@
+WITH
+  base AS (
+    SELECT
+    application.id,
+    application.application_type,
+    application.created_at AS submission_date,
+    application.state AS decision,
+    (app_ver.application ->> 'office_code')::text AS office_code,
+    (app_ver.created_at)::timestamp AS decision_date
+    FROM application_version AS app_ver
+    INNER JOIN application ON app_ver.application_id = application.id
+    INNER JOIN (
+      SELECT application_id, MAX(created_at) AS max_created_at
+      FROM application_version
+      GROUP BY application_id
+    )  AS latest_decision ON app_ver.application_id = latest_decision.application_id
+                          AND  app_ver.created_at = latest_decision.max_created_at
+    WHERE (app_ver.application ->> 'status')::text IN ('rejected', 'part_grant', 'granted')
+  ),
+  assignment_events AS (
+    SELECT
+      id,
+      (events ->> 'created_at')::timestamp AS assigned_at
+    FROM application
+    CROSS JOIN jsonb_array_elements(caseworker_history_events) as events
+    WHERE events ->> 'event_type' = 'assignment'
+  )
+
+SELECT *,
+  EXTRACT(EPOCH FROM (decision_date - submission_date))/60 AS minutes_to_assess
+FROM base


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM456-2519)

## Notes for reviewer
Adds new view for assessment times with per application: 

- application id
- office code
- application type
- submission_date (created_at of application record) 
- first decision (the status of the first application_version record that has a application->status of a decision state)
- first decision date (the created_at of the first application_version record that has a application->status of a decision date)
- first assigned date (the created_at of the first assignment event on the application's caseworker_history_events array)
- minutes to assign (difference between submission date and first assigned date in minutes) 
- minutes to assess (difference between first assigned date and first decision date in minutes)

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
