### PR TITLE
CRM457-2519: Create Metrics Report for Time To Assess A Claim pt 2

### DIFF
--- a/db/migrate/20250520133235_update_submission_assess_times_to_version_2.rb
+++ b/db/migrate/20250520133235_update_submission_assess_times_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateSubmissionAssessTimesToVersion2 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :submission_assess_times, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_14_155430) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_20_133235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -263,7 +263,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_14_155430) do
                       min(application_version.created_at) AS decision_created_at
                      FROM application_version
                     GROUP BY application_version.application_id, application_version.application) first_decision ON ((application.id = first_decision.application_id)))
-            WHERE ((first_decision.application ->> 'status'::text) = ANY (ARRAY['rejected'::text, 'part_grant'::text, 'granted'::text]))
+            WHERE (((first_decision.application ->> 'status'::text) = ANY (ARRAY['rejected'::text, 'part_grant'::text, 'granted'::text])) AND (first_decision.decision_created_at IS NOT NULL))
           ), assignment_events AS (
            SELECT application.id,
               ((events.value ->> 'created_at'::text))::timestamp without time zone AS assigned_at

--- a/db/views/submission_assess_times_v02.sql
+++ b/db/views/submission_assess_times_v02.sql
@@ -1,0 +1,44 @@
+WITH
+  base AS (
+    SELECT
+    application.id,
+    application.application_type,
+    application.created_at AS submission_date,
+    (first_decision.application ->> 'status')::text AS first_decision,
+    (first_decision.application ->> 'office_code')::text AS office_code,
+    first_decision.decision_created_at AS first_decision_date
+    FROM application
+    INNER JOIN (
+      SELECT application_id, application, MIN(created_at) AS decision_created_at
+      FROM application_version
+      GROUP BY application_id, application
+    )  AS first_decision ON application.id = first_decision.application_id
+    WHERE
+      (first_decision.application ->> 'status')::text IN ('rejected', 'part_grant', 'granted')
+       AND decision_created_at IS NOT NULL
+  ),
+  assignment_events AS (
+    SELECT
+      id,
+      (events ->> 'created_at')::timestamp AS assigned_at
+    FROM application
+    CROSS JOIN jsonb_array_elements(caseworker_history_events) as events
+    WHERE events ->> 'event_type' = 'assignment'
+  )
+
+SELECT
+	base.id,
+	base.application_type,
+	base.submission_date,
+	base.office_code,
+	first_decision,
+	first_decision_date,
+	first_assigned_date,
+	EXTRACT(EPOCH FROM (first_assigned_date - submission_date))/60 AS minutes_to_assign,
+	EXTRACT(EPOCH FROM (first_decision_date - first_assigned_date))/60 AS minutes_to_assess
+FROM base
+INNER JOIN (
+  SELECT id, MIN(assigned_at) AS first_assigned_date
+  FROM assignment_events
+  GROUP BY id
+) AS first_assignment ON base.id = first_assignment.id


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2519)

## Notes for reviewer
Filter out records where decision state Submission Version records have null created_at. These are in there because of a datafix that was needed to backfill some records that didn't get created when they should have. At the time there was no way of discerning the created_at value so the updated_at value was only updated with the date of the data fix


