### PR TITLE
CRM457-2746: Notify App Store Failing with Disbursement That Has No Miles

### DIFF
--- a/app/presenters/V1/nsm/disbursement_costs_presenter.rb
+++ b/app/presenters/V1/nsm/disbursement_costs_presenter.rb
@@ -5,11 +5,12 @@ module V1
         @disbursement = disbursement
       end
 
+      # TODO: Add real assessed costs if using caseworker assessed data
       def data_for_calculation
         {
           disbursement_type: @disbursement["disbursement_type"],
           claimed_cost: @disbursement["total_cost_without_vat"],
-          claimed_miles: BigDecimal(@disbursement["miles"].to_s),
+          claimed_miles: BigDecimal(disbursement_miles),
           claimed_apply_vat: apply_vat?,
           assessed_cost: 0,
           assessed_miles: BigDecimal(0),
@@ -19,6 +20,10 @@ module V1
 
       def apply_vat?
         @disbursement["apply_vat"].in?([true, "true"])
+      end
+
+      def disbursement_miles
+        @disbursement["miles"].to_s.presence || 0
       end
     end
   end

--- a/app/presenters/V1/nsm/letters_and_calls_costs_presenter.rb
+++ b/app/presenters/V1/nsm/letters_and_calls_costs_presenter.rb
@@ -9,6 +9,7 @@ module V1
         [letters_for_calculation, calls_for_calculation]
       end
 
+       # TODO: Add real assessed costs if using caseworker assessed data
       def calls_for_calculation
         {
           type: :calls,

--- a/app/presenters/V1/nsm/work_item_costs_presenter.rb
+++ b/app/presenters/V1/nsm/work_item_costs_presenter.rb
@@ -6,6 +6,7 @@ module V1
         @claim = claim
       end
 
+       # TODO: Add real assessed costs if using caseworker assessed data
       def data_for_calculation
         {
           claimed_time_spent_in_minutes: @work_item["time_spent"].to_i,

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -238,5 +238,23 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_other_disbursement do
+      disbursements do
+        [
+          {
+            "disbursement_date" => Time.zone.local(2025, 1, 1),
+            "disbursement_type" => "other",
+            "other_type" => "test",
+            "miles" => "",
+            "position" => 1,
+            "details" => "Some stuff that was bought",
+            "vat_rate" => 0.2,
+            "total_cost_without_vat" => 350.33,
+            "apply_vat" => true,
+          },
+        ]
+      end
+    end
   end
 end

--- a/spec/presenters/v1/nsm/disbursement_costs_presenter_spec.rb
+++ b/spec/presenters/v1/nsm/disbursement_costs_presenter_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe V1::Nsm::DisbursementCostsPresenter do
+  describe "#data_for_calculation" do
+    context "when disbursement type is other (no miles)" do
+      let(:application) { build(:application, :with_other_disbursement) }
+      let(:disbursement) { application[:disbursements].first }
+
+      it "default miles to 0 if value for miles is empty string" do
+        expect{described_class.new(disbursement).data_for_calculation}.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2746)

## Notes for reviewer

- Safely extract disbursement miles when no value entered for email cost calculations
- Add some additional comments to warn of tech debt where assessed costs are always compulsory for cost calculators
