### PR TITLE
CRM457-3031: Add composite application search index

### DIFF
--- a/db/migrate/20260429090951_add_index_to_application_on_application_type_and_last_updated_at.rb
+++ b/db/migrate/20260429090951_add_index_to_application_on_application_type_and_last_updated_at.rb
@@ -1,0 +1,22 @@
+class AddIndexToApplicationOnApplicationTypeAndLastUpdatedAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "idx_application_on_type_last_updated_at"
+
+  def up
+    return if index_exists?(:application, %i[application_type last_updated_at], name: INDEX_NAME)
+
+    add_index :application,
+              %i[application_type last_updated_at],
+              name: INDEX_NAME,
+              algorithm: :concurrently
+  end
+
+  def down
+    return unless index_exists?(:application, name: INDEX_NAME)
+
+    remove_index :application,
+                 name: INDEX_NAME,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_080100) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_090951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -29,6 +29,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_080100) do
     t.text "state", null: false
     t.string "unassigned_user_ids", default: [], array: true
     t.datetime "updated_at", precision: nil
+    t.index ["application_type", "last_updated_at"], name: "idx_application_on_type_last_updated_at"
     t.check_constraint "created_at IS NOT NULL", name: "application_created_at_null"
     t.check_constraint "updated_at IS NOT NULL", name: "application_updated_at_null"
   end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3031)

Adds a composite index on `application(application_type, last_updated_at)` to support Prior Authority dashboard searches ordered by latest update.

This PR is intentionally index-only so it can be rolled out first. The `searches` view rewrite is split into a separate follow-up PR for next week.

## Notes for reviewer

The new index is created concurrently and is rollbackable.

This index gives Postgres an ordered access path for dashboard queries such as:

```sql
WHERE application_type = 'crm4'
ORDER BY last_updated_at DESC
LIMIT ...
```

Local benchmarking showed the largest improvement comes when this index is combined with the follow-up `searches` view rewrite. This PR lays down the index first so we can deploy it separately and observe safely.

## Screenshots of changes (if applicable)

N/A

## How to manually test the feature

Run the migration and rollback locally:

```sh
RAILS_ENV=test bundle exec rails db:migrate
RAILS_ENV=test bundle exec rails db:rollback STEP=1
RAILS_ENV=test bundle exec rails db:migrate
```
