### PR TITLE
CRM457-3031: Optimise searches view

### DIFF
--- a/db/migrate/20260430090000_update_searches_to_version_10.rb
+++ b/db/migrate/20260430090000_update_searches_to_version_10.rb
@@ -1,0 +1,5 @@
+class UpdateSearchesToVersion10 < ActiveRecord::Migration[8.1]
+  def change
+    update_view :searches, version: 10, revert_to_version: 9
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_090951) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -236,47 +236,43 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_090951) do
      FROM base;
   SQL
   create_view "searches", sql_definition: <<-SQL
-      WITH defendants AS (
-           SELECT app_1.id,
-                  CASE
-                      WHEN (app_1.application_type = 'crm4'::text) THEN ((((app_ver_1.application -> 'defendant'::text) ->> 'first_name'::text) || ' '::text) || ((app_ver_1.application -> 'defendant'::text) ->> 'last_name'::text))
-                      ELSE ( SELECT (((defendants.value ->> 'first_name'::text) || ' '::text) || (defendants.value ->> 'last_name'::text))
-                         FROM jsonb_array_elements((app_ver_1.application -> 'defendants'::text)) defendants(value)
-                        WHERE ((defendants.value ->> 'main'::text) = 'true'::text))
-                  END AS client_name
-             FROM (application app_1
-               JOIN application_version app_ver_1 ON (((app_1.id = app_ver_1.application_id) AND (app_1.current_version = app_ver_1.version))))
-          )
-   SELECT app.id,
-      app_ver.id AS application_version_id,
-      (app_ver.application ->> 'ufn'::text) AS ufn,
-      (app_ver.application ->> 'laa_reference'::text) AS laa_reference,
-      ((app_ver.application -> 'firm_office'::text) ->> 'name'::text) AS firm_name,
-      ((app_ver.application -> 'firm_office'::text) ->> 'account_number'::text) AS account_number,
-      (app_ver.application ->> 'service_name'::text) AS service_name,
-      (((app_ver.application -> 'cost_summary'::text) ->> 'high_value'::text))::boolean AS high_value,
-      app_ver.created_at AS last_state_change,
-          CASE app.application_risk
-              WHEN 'high'::text THEN 3
-              WHEN 'medium'::text THEN 2
-              ELSE 1
-          END AS risk_level,
-      def.client_name,
-      app_ver.search_fields,
-      app.unassigned_user_ids,
-      app.assigned_user_id,
-      app.created_at AS date_submitted,
-      app.last_updated_at AS last_updated,
-          CASE
-              WHEN ((app.state = 'submitted'::text) AND (app.assigned_user_id IS NOT NULL)) THEN 'in_progress'::text
-              WHEN ((app.state = 'submitted'::text) AND (app.assigned_user_id IS NULL)) THEN 'not_assigned'::text
-              ELSE app.state
-          END AS status_with_assignment,
-      app.application_type,
-      app.application_risk AS risk
-     FROM ((application app
-       JOIN application_version app_ver ON (((app.id = app_ver.application_id) AND (app.current_version = app_ver.version))))
-       JOIN defendants def ON ((def.id = app.id)));
+      SELECT
+        app.id,
+        app_ver.id as application_version_id,
+        app_ver.application ->> 'ufn' as ufn,
+        app_ver.application ->> 'laa_reference' as laa_reference,
+        app_ver.application -> 'firm_office' ->> 'name' as firm_name,
+        app_ver.application -> 'firm_office' ->> 'account_number' as account_number,
+        app_ver.application ->> 'service_name' as service_name,
+        (app_ver.application -> 'cost_summary' ->> 'high_value')::boolean as high_value,
+        app_ver.created_at as last_state_change,
+        CASE app.application_risk
+        WHEN 'high' THEN 3
+        WHEN 'medium' THEN 2
+        ELSE 1 END as risk_level,
+        CASE WHEN app.application_type = 'crm4' THEN
+            (app_ver.application -> 'defendant' ->> 'first_name') || ' ' || (app_ver.application -> 'defendant' ->> 'last_name')
+           ELSE
+            (
+              SELECT (defendants.value->>'first_name') || ' ' || (defendants.value->>'last_name')
+              FROM jsonb_array_elements(app_ver.application->'defendants') AS defendants
+              WHERE defendants.value->>'main' = 'true'
+            )
+           END AS client_name,
+        app_ver.search_fields,
+        app.unassigned_user_ids,
+        app.assigned_user_id,
+        app.created_at as date_submitted,
+        app.last_updated_at as last_updated,
+        CASE WHEN app.state = 'submitted' AND app.assigned_user_id IS NOT NULL THEN 'in_progress'
+             WHEN app.state = 'submitted' AND app.assigned_user_id IS NULL THEN 'not_assigned'
+             ELSE app.state
+             END AS status_with_assignment,
+        app.application_type as application_type,
+        app.application_risk as risk
+      FROM application AS app
+      JOIN application_version AS app_ver
+        ON app.id = app_ver.application_id AND app.current_version = app_ver.version
   SQL
   create_view "submission_assess_times", sql_definition: <<-SQL
       WITH base AS (

--- a/db/views/searches_v10.sql
+++ b/db/views/searches_v10.sql
@@ -1,0 +1,37 @@
+SELECT
+  app.id,
+  app_ver.id as application_version_id,
+  app_ver.application ->> 'ufn' as ufn,
+  app_ver.application ->> 'laa_reference' as laa_reference,
+  app_ver.application -> 'firm_office' ->> 'name' as firm_name,
+  app_ver.application -> 'firm_office' ->> 'account_number' as account_number,
+  app_ver.application ->> 'service_name' as service_name,
+  (app_ver.application -> 'cost_summary' ->> 'high_value')::boolean as high_value,
+  app_ver.created_at as last_state_change,
+  CASE app.application_risk
+  WHEN 'high' THEN 3
+  WHEN 'medium' THEN 2
+  ELSE 1 END as risk_level,
+  CASE WHEN app.application_type = 'crm4' THEN
+      (app_ver.application -> 'defendant' ->> 'first_name') || ' ' || (app_ver.application -> 'defendant' ->> 'last_name')
+     ELSE
+      (
+        SELECT (defendants.value->>'first_name') || ' ' || (defendants.value->>'last_name')
+        FROM jsonb_array_elements(app_ver.application->'defendants') AS defendants
+        WHERE defendants.value->>'main' = 'true'
+      )
+     END AS client_name,
+  app_ver.search_fields,
+  app.unassigned_user_ids,
+  app.assigned_user_id,
+  app.created_at as date_submitted,
+  app.last_updated_at as last_updated, -- latest event's created_at date in most instances
+  CASE WHEN app.state = 'submitted' AND app.assigned_user_id IS NOT NULL THEN 'in_progress'
+       WHEN app.state = 'submitted' AND app.assigned_user_id IS NULL THEN 'not_assigned'
+       ELSE app.state
+       END AS status_with_assignment,
+  app.application_type as application_type,
+  app.application_risk as risk
+FROM application AS app
+JOIN application_version AS app_ver
+  ON app.id = app_ver.application_id AND app.current_version = app_ver.version

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,6 +1,103 @@
 require "rails_helper"
 
 RSpec.describe Search do
+  describe "view projection" do
+    it "exposes the search API column contract" do
+      expect(described_class.column_names).to contain_exactly(
+        "id",
+        "application_version_id",
+        "ufn",
+        "laa_reference",
+        "firm_name",
+        "account_number",
+        "service_name",
+        "high_value",
+        "last_state_change",
+        "risk_level",
+        "client_name",
+        "search_fields",
+        "unassigned_user_ids",
+        "assigned_user_id",
+        "date_submitted",
+        "last_updated",
+        "status_with_assignment",
+        "application_type",
+        "risk",
+      )
+      expect(described_class.columns_hash.fetch("high_value").type).to be(:boolean)
+    end
+
+    it "projects prior authority fields from the current submission version" do
+      created_at = Time.zone.local(2026, 4, 1, 10, 0, 0)
+      last_updated_at = Time.zone.local(2026, 4, 2, 11, 0, 0)
+      submission = create(
+        :submission,
+        :with_pa_version,
+        application_risk: "high",
+        assigned_user_id: "caseworker-id",
+        unassigned_user_ids: %w[previous-caseworker-id],
+        defendant_name: "Ada Lovelace",
+        firm_name: "Analytical Engines LLP",
+        account_number: "1A111A",
+        ufn: "111111/111",
+        laa_reference: "LAA-AAAAA1",
+        created_at:,
+        last_updated_at:,
+      )
+
+      search = described_class.find(submission.id)
+
+      expect(search).to have_attributes(
+        application_version_id: submission.latest_version.id,
+        ufn: "111111/111",
+        laa_reference: "LAA-AAAAA1",
+        firm_name: "Analytical Engines LLP",
+        account_number: "1A111A",
+        service_name: nil,
+        high_value: nil,
+        risk_level: 3,
+        client_name: "Ada Lovelace",
+        unassigned_user_ids: %w[previous-caseworker-id],
+        assigned_user_id: "caseworker-id",
+        date_submitted: created_at,
+        last_updated: last_updated_at,
+        status_with_assignment: "in_progress",
+        application_type: "crm4",
+        risk: "high",
+      )
+    end
+
+    it "projects non-standard magistrates fields from the main defendant" do
+      submission = create(
+        :submission,
+        build_scope: [:with_nsm_application_high_value],
+        application_type: "crm7",
+        defendant_name: "Grace Hopper",
+        additional_defendant_names: ["Margaret Hamilton"],
+        firm_name: "Compiler & Co",
+        account_number: "2B222B",
+        ufn: "222222/222",
+        laa_reference: "LAA-BBBBB2",
+      )
+
+      search = described_class.find(submission.id)
+
+      expect(search).to have_attributes(
+        application_version_id: submission.latest_version.id,
+        ufn: "222222/222",
+        laa_reference: "LAA-BBBBB2",
+        firm_name: "Compiler & Co",
+        account_number: "2B222B",
+        high_value: true,
+        risk_level: 1,
+        client_name: "Grace Hopper",
+        status_with_assignment: "not_assigned",
+        application_type: "crm7",
+        risk: "low",
+      )
+    end
+  end
+
   describe "#where_terms" do
     let(:search) { described_class.where_terms(query).pluck(:id) }
     let(:prepare) { build(:submission).tap(&:save) }


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3031)

Updates the `searches` view to v10 to improve Prior Authority dashboard search performance.

This is split out from the index PR so the composite index can be deployed first. This PR only contains the view rewrite and direct view coverage.

## Notes for reviewer

The previous `searches` view joined `application` to the current `application_version` once inside a `defendants` CTE, then repeated the same current-version join in the outer query.

The v10 view removes that duplicated join and calculates `client_name` inline from the already-joined current version.

Additional model specs now cover the view contract:

- expected search columns
- PA/CRM4 projection
- NSM/CRM7 projection
- `client_name`
- `status_with_assignment`
- `risk_level`
- boolean `high_value`

### Local benchmark

I used the bulk dummy-data generation task from the Submit data-generation work in a local-only benchmark branch to seed the App Store test database:

```sh
RAILS_ENV=test \
APPLICATION_TYPE=crm4 \
SUBMISSIONS_COUNT=250000 \
PROVIDER_COUNT=1 \
OFFICE_CODES_PER_PROVIDER=128 \
MAX_VERSIONS_PER_SUBMISSION=4 \
BATCH_SIZE=5000 \
RANDOM_SEED=30321788 \
bundle exec rails db:seeds:submissions
```

Dataset:

- 250,000 `application` rows
- 625,000 `application_version` rows
- 128 CRM4 account numbers
- 1, 2, 3, and 4 versions evenly distributed
- varied PA dashboard states including `not_assigned`, `provider_updated`, `granted`, `part_grant`, `rejected`, `auto_grant`, and `sent_back`

Key result on the 250k CRM4 / 625k version dataset:

| Query | v09 | v10 | Change |
| --- | ---: | ---: | ---: |
| reviewed list, 32 accounts | 265ms | 1.3ms | -99.5% |
| reviewed count, 32 accounts | 269ms | 177ms | -34% |
| submitted list, 32 accounts | 177ms | 1.5ms | -99.1% |
| submitted count, 32 accounts | 181ms | 126ms | -30% |

The main improvement is for first-page dashboard list retrieval. Count queries improve, but exact counts remain materially heavier because they still need to inspect all matching rows.

## Screenshots of changes (if applicable)

N/A

## How to manually test the feature

```sh
NOCOVERAGE=1 RAILS_ENV=test bundle exec rspec spec/models/search_spec.rb spec/requests/submissions_search_spec.rb
```

Expected:

```sh
97 examples, 0 failures
```

The view migration is rollbackable through Scenic:

```sh
RAILS_ENV=test bundle exec rails db:rollback STEP=1
RAILS_ENV=test bundle exec rails db:migrate
```
