### PR TITLE
CRM457-2903: Payments QA Fixes (NSM)

### DIFF
--- a/app/services/payment_requests/create_payment_request_service.rb
+++ b/app/services/payment_requests/create_payment_request_service.rb
@@ -139,7 +139,7 @@ module PaymentRequests
 
     def persist_linked_submission!(claim)
       linked_laa_reference = params[:linked_laa_reference]
-      submission_id = params[:id]
+      submission_id = params[:submission_id]
       return unless linked_laa_reference.present? && submission_id.present?
 
       linked_submission = find_referred_submission(linked_laa_reference)

--- a/spec/services/payment_requests/create_payment_request_service_spec.rb
+++ b/spec/services/payment_requests/create_payment_request_service_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe PaymentRequests::CreatePaymentRequestService, type: :service do
 
     context "when a submission exists for the linked reference" do
       let!(:submission) { create(:submission, :with_nsm_version, laa_reference: linked_laa_reference) }
-      let(:params) { super().merge(linked_laa_reference:, id: submission.id) }
+      let(:params) { super().merge(linked_laa_reference:, submission_id: submission.id) }
 
       it "stores the submission id on the claim" do
         result = service.call


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2903)

## Notes for reviewer

- Explicitly use key "submission_id" instead of "id" from payload to link payment to CRM7 Submission record
- To be merged in conjunction with [Assess PR 1213](https://github.com/ministryofjustice/laa-assess-crime-forms/pull/1213)