### PR TITLE
CRM457-3051: Make Views More Efficient: Processing Times

### DIFF
--- a/db/migrate/20260602100000_update_processing_times_to_version_4.rb
+++ b/db/migrate/20260602100000_update_processing_times_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateProcessingTimesToVersion4 < ActiveRecord::Migration[8.1]
+  def change
+    update_view :processing_times, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -211,28 +211,31 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_090000) do
            SELECT application.id,
               application.application_type,
               application_version.version,
-              COALESCE(lag((application_version.application ->> 'status'::text), 1) OVER (PARTITION BY application_version.application_id ORDER BY application_version.version), 'draft'::text) AS from_status,
-              (COALESCE(lag((application_version.application ->> 'updated_at'::text), 1) OVER (PARTITION BY application_version.application_id ORDER BY application_version.version), (application_version.application ->> 'created_at'::text)))::timestamp without time zone AS from_time,
+              COALESCE((previous_application_version.application ->> 'status'::text), 'draft'::text) AS from_status,
+              (COALESCE((previous_application_version.application ->> 'updated_at'::text), (application_version.application ->> 'created_at'::text)))::timestamp without time zone AS from_time,
               (application_version.application ->> 'status'::text) AS to_status,
               ((application_version.application ->> 'updated_at'::text))::timestamp without time zone AS to_time,
-                  CASE
-                      WHEN (((application_version.application ->> 'import_date'::text))::timestamp without time zone IS NOT NULL) THEN true
-                      ELSE false
-                  END AS claim_imported
-             FROM (application_version
-               JOIN application ON (((application_version.application_id = application.id) AND (application_version.pending IS FALSE))))
+              (NULLIF((application_version.application ->> 'import_date'::text), ''::text) IS NOT NULL) AS claim_imported
+             FROM ((application_version
+               JOIN application ON ((application_version.application_id = application.id)))
+               LEFT JOIN LATERAL ( SELECT previous_application_version_1.application
+                     FROM application_version previous_application_version_1
+                    WHERE ((previous_application_version_1.application_id = application_version.application_id) AND (previous_application_version_1.pending IS FALSE) AND (previous_application_version_1.version < application_version.version))
+                    ORDER BY previous_application_version_1.version DESC
+                   LIMIT 1) previous_application_version ON (true))
+            WHERE (application_version.pending IS FALSE)
           )
-   SELECT base.id,
-      base.application_type,
-      base.version,
-      base.from_status,
-      base.from_time,
-      base.to_status,
-      base.to_time,
-      base.claim_imported,
-      (base.from_time)::date AS from_date,
-      (base.to_time)::date AS to_date,
-      GREATEST(EXTRACT(epoch FROM (base.to_time - base.from_time)), (0)::numeric) AS processing_seconds
+   SELECT id,
+      application_type,
+      version,
+      from_status,
+      from_time,
+      to_status,
+      to_time,
+      claim_imported,
+      (from_time)::date AS from_date,
+      (to_time)::date AS to_date,
+      GREATEST(EXTRACT(epoch FROM (to_time - from_time)), (0)::numeric) AS processing_seconds
      FROM base;
   SQL
   create_view "searches", sql_definition: <<-SQL

--- a/db/views/processing_times_v04.sql
+++ b/db/views/processing_times_v04.sql
@@ -1,0 +1,33 @@
+WITH base AS (
+  SELECT
+    application.id,
+    application.application_type,
+    application_version.version,
+    COALESCE(previous_application_version.application ->> 'status', 'draft') AS from_status,
+    COALESCE(
+      previous_application_version.application ->> 'updated_at',
+      application_version.application ->> 'created_at'
+    )::timestamp AS from_time,
+    application_version.application ->> 'status' AS to_status,
+    (application_version.application ->> 'updated_at')::timestamp AS to_time,
+    NULLIF(application_version.application ->> 'import_date', '') IS NOT NULL AS claim_imported
+  FROM application_version
+  JOIN application ON application_version.application_id = application.id
+  LEFT JOIN LATERAL (
+    SELECT previous_application_version.application
+    FROM application_version AS previous_application_version
+    WHERE previous_application_version.application_id = application_version.application_id
+      AND previous_application_version.pending IS FALSE
+      AND previous_application_version.version < application_version.version
+    ORDER BY previous_application_version.version DESC
+    LIMIT 1
+  ) AS previous_application_version ON TRUE
+  WHERE application_version.pending IS FALSE
+)
+
+SELECT
+  *,
+  from_time::date AS from_date,
+  to_time::date AS to_date,
+  GREATEST(EXTRACT(epoch FROM (to_time - from_time)), 0) AS processing_seconds
+FROM base

--- a/spec/postgres_views/processing_times_spec.rb
+++ b/spec/postgres_views/processing_times_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "processing times" do
         "to_status" => "approved",
         "to_time" => Time.zone.local(2024, 6, 26, 12, 20),
         "version" => 2,
-      "claim_imported" => false },
+        "claim_imported" => false },
     )
   end
 

--- a/spec/postgres_views/processing_times_spec.rb
+++ b/spec/postgres_views/processing_times_spec.rb
@@ -2,10 +2,16 @@ require "rails_helper"
 
 RSpec.describe "processing times" do
   let(:base_time) { Time.zone.local(2024, 6, 26, 12) }
+  let(:view_definition) { Rails.root.join("db/views/processing_times_v04.sql").read }
   let(:klass) do
     Class.new(ApplicationRecord) do
       self.table_name = :processing_times
     end
+  end
+
+  it "uses an indexed previous-version lookup rather than windowing all versions" do
+    expect(view_definition).to include("JOIN LATERAL")
+    expect(view_definition).not_to match(/\bLAG\s*\(/i)
   end
 
   it "records draft to submitted when only one version" do
@@ -43,7 +49,25 @@ RSpec.describe "processing times" do
         "to_status" => "approved",
         "to_time" => Time.zone.local(2024, 6, 26, 12, 20),
         "version" => 2,
-        "claim_imported" => false },
+      "claim_imported" => false },
+    )
+  end
+
+  it "ignores pending versions when deriving the previous state" do
+    submission = travel_to(base_time) { create(:submission, :with_pa_version) }
+    travel_to(base_time + 20.minutes) do
+      create(:submission_version, :with_pa_application, submission:, status: "sent_back", pending: true, version: 2)
+    end
+    travel_to(base_time + 40.minutes) do
+      create(:submission_version, :with_pa_application, submission:, status: "approved", version: 3)
+    end
+
+    expect(klass.find_by(version: 3).attributes).to include(
+      "from_status" => "submitted",
+      "from_time" => Time.zone.local(2024, 6, 26, 12),
+      "processing_seconds" => 2400.0,
+      "to_status" => "approved",
+      "to_time" => Time.zone.local(2024, 6, 26, 12, 40),
     )
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3051)

Optimises the `processing_times` Scenic view used by the NSCC Team Metrics Metabase dashboard.

The view previously used `LAG(...)` window functions over all non-pending application versions to derive previous status and timestamps. This PR changes that to a lateral previous-version lookup, using the existing `application_id, version` index shape, so dashboard filters on current rows can reduce the working set before previous-state lookup.

## Notes for reviewer

The Metabase dashboard has several cards backed by `processing_times`, including `Question - Caseworker Processing Times`, `Question - RFI per Application`, and `Rejected vs Claimed`. Local benchmarking against Metabase-like query shapes showed materially lower execution time and buffer pressure.

Local benchmark dataset:

- `301,022` applications
- `376,032` application versions
- `376,032` processing-time rows

Local `EXPLAIN (ANALYZE, BUFFERS)` comparison:

| Query shape | v3 | v4 |
| --- | ---: | ---: |
| Caseworker Processing Times | 695.7ms | 78.9ms |
| RFI per Application | 75.0ms | 34.4ms |
| Rejected vs Claimed | 770.4ms | 36.0ms |

The `Rejected vs Claimed` query also dropped from `temp_read: 189,924` to `temp_read: 0` locally.

## How to manually test the feature

For operational verification, run a controlled UAT/prod-style dashboard check against Team Metrics while monitoring DB read IOPS/AAS, because the production risk is concurrent Metabase dashboard load rather than only single-query correctness.