### PR TITLE
CRM457-2957: Generate CRM8 AC payment dashboard view

### DIFF
--- a/db/migrate/20260608150700_create_assigned_counsel_payments.rb
+++ b/db/migrate/20260608150700_create_assigned_counsel_payments.rb
@@ -1,0 +1,5 @@
+class CreateAssignedCounselPayments < ActiveRecord::Migration[8.1]
+  def change
+    create_view :assigned_counsel_payments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,6 +199,42 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
     GROUP BY dates.day
     ORDER BY dates.day;
   SQL
+  create_view "assigned_counsel_payments", sql_definition: <<-SQL
+      SELECT payment_requests.id AS payment_request_id,
+      payable_claims.id AS claim_id,
+      payable_claims.laa_reference,
+          CASE payment_requests.request_type
+              WHEN 'assigned_counsel'::text THEN 'AC'::text
+              WHEN 'assigned_counsel_appeal'::text THEN 'AC Appeal'::text
+              WHEN 'assigned_counsel_amendment'::text THEN 'AC Amendment'::text
+              ELSE NULL::text
+          END AS payment_type,
+      'CRM8'::text AS description,
+      'CL_CON_CWA'::text AS invoice_type,
+      NULLIF(TRIM(BOTH FROM concat_ws(' '::text, payable_claims.client_first_name, payable_claims.client_last_name)), ''::text) AS client_name,
+      payable_claims.ufn AS case_reference,
+      (payment_requests.submitted_at)::date AS date_requested,
+      payable_claims.counsel_office_code AS office_code,
+      COALESCE(payment_requests.allowed_total, (COALESCE(payment_requests.allowed_net_assigned_counsel_cost, (0)::numeric) + COALESCE(payment_requests.allowed_assigned_counsel_vat, (0)::numeric))) AS invoice_amount_inc_vat,
+          CASE
+              WHEN (COALESCE(payment_requests.allowed_assigned_counsel_vat, payment_requests.claimed_assigned_counsel_vat, (0)::numeric) = (0)::numeric) THEN 0
+              ELSE 20
+          END AS tax_amount_percentage,
+      'Profit costs'::text AS fee_type,
+      payable_claims.counsel_firm_name AS provider_reference,
+      payment_requests.request_type,
+      payment_requests.claimed_net_assigned_counsel_cost,
+      payment_requests.claimed_assigned_counsel_vat,
+      payment_requests.claimed_total,
+      payment_requests.allowed_net_assigned_counsel_cost,
+      payment_requests.allowed_assigned_counsel_vat,
+      payment_requests.allowed_total,
+      payment_requests.date_claim_assessed,
+      payment_requests.submitted_at
+     FROM (payment_requests
+       JOIN payable_claims ON ((payment_requests.payable_claim_id = payable_claims.id)))
+    WHERE ((payment_requests.request_type)::text = ANY ((ARRAY['assigned_counsel'::character varying, 'assigned_counsel_appeal'::character varying, 'assigned_counsel_amendment'::character varying])::text[]));
+  SQL
   create_view "autogrant_events", sql_definition: <<-SQL
       SELECT a.id,
       av.version AS submission_version,
@@ -235,11 +271,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
       payment_requests.claimed_waiting_cost,
       payment_requests.claimed_total,
       payment_requests.allowed_total,
-      payment_requests.date_claim_assessed AS date_received,
+      payment_requests.date_claim_assessed,
       payment_requests.submitted_at
      FROM (payment_requests
        JOIN payable_claims ON ((payment_requests.payable_claim_id = payable_claims.id)))
-    WHERE ((payment_requests.request_type)::text = ANY ((ARRAY['breach_of_injunction'::character varying, 'non_standard_magistrate'::character varying, 'non_standard_mag_supplemental'::character varying, 'non_standard_mag_appeal'::character varying, 'non_standard_mag_amendment'::character varying])::text[]));
+    WHERE ((payment_requests.request_type)::text = ANY (ARRAY[('breach_of_injunction'::character varying)::text, ('non_standard_magistrate'::character varying)::text, ('non_standard_mag_supplemental'::character varying)::text, ('non_standard_mag_appeal'::character varying)::text, ('non_standard_mag_amendment'::character varying)::text]));
   SQL
   create_view "processing_times", sql_definition: <<-SQL
       WITH base AS (

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,7 +213,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
       'CL_CON_CWA'::text AS invoice_type,
       NULLIF(TRIM(BOTH FROM concat_ws(' '::text, payable_claims.client_first_name, payable_claims.client_last_name)), ''::text) AS client_name,
       payable_claims.ufn AS case_reference,
-      (payment_requests.submitted_at)::date AS date_requested,
+      (payment_requests.date_claim_assessed)::date AS date_requested,
       payable_claims.counsel_office_code AS office_code,
       COALESCE(payment_requests.allowed_total, (COALESCE(payment_requests.allowed_net_assigned_counsel_cost, (0)::numeric) + COALESCE(payment_requests.allowed_assigned_counsel_vat, (0)::numeric))) AS invoice_amount_inc_vat,
           CASE

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -215,7 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
       payable_claims.ufn AS case_reference,
       (payment_requests.date_claim_assessed)::date AS date_requested,
       payable_claims.counsel_office_code AS office_code,
-      COALESCE(payment_requests.allowed_total, (COALESCE(payment_requests.allowed_net_assigned_counsel_cost, (0)::numeric) + COALESCE(payment_requests.allowed_assigned_counsel_vat, (0)::numeric))) AS invoice_amount_inc_vat,
+      payment_requests.allowed_total AS invoice_amount_inc_vat,
           CASE
               WHEN (COALESCE(payment_requests.allowed_assigned_counsel_vat, payment_requests.claimed_assigned_counsel_vat, (0)::numeric) = (0)::numeric) THEN 0
               ELSE 20

--- a/db/views/assigned_counsel_payments_v01.sql
+++ b/db/views/assigned_counsel_payments_v01.sql
@@ -14,7 +14,7 @@ SELECT
     ''
   ) AS client_name,
   payable_claims.ufn AS case_reference,
-  payment_requests.submitted_at::date AS date_requested,
+  payment_requests.date_claim_assessed::date AS date_requested,
   payable_claims.counsel_office_code AS office_code,
   COALESCE(
     payment_requests.allowed_total,

--- a/db/views/assigned_counsel_payments_v01.sql
+++ b/db/views/assigned_counsel_payments_v01.sql
@@ -16,11 +16,7 @@ SELECT
   payable_claims.ufn AS case_reference,
   payment_requests.date_claim_assessed::date AS date_requested,
   payable_claims.counsel_office_code AS office_code,
-  COALESCE(
-    payment_requests.allowed_total,
-    COALESCE(payment_requests.allowed_net_assigned_counsel_cost, 0) +
-      COALESCE(payment_requests.allowed_assigned_counsel_vat, 0)
-  ) AS invoice_amount_inc_vat,
+  payment_requests.allowed_total AS invoice_amount_inc_vat,
   CASE
     WHEN COALESCE(payment_requests.allowed_assigned_counsel_vat, payment_requests.claimed_assigned_counsel_vat, 0) = 0 THEN 0
     ELSE 20

--- a/db/views/assigned_counsel_payments_v01.sql
+++ b/db/views/assigned_counsel_payments_v01.sql
@@ -1,0 +1,47 @@
+SELECT
+  payment_requests.id AS payment_request_id,
+  payable_claims.id AS claim_id,
+  payable_claims.laa_reference AS laa_reference,
+  CASE payment_requests.request_type
+    WHEN 'assigned_counsel' THEN 'AC'
+    WHEN 'assigned_counsel_appeal' THEN 'AC Appeal'
+    WHEN 'assigned_counsel_amendment' THEN 'AC Amendment'
+  END AS payment_type,
+  'CRM8' AS description,
+  'CL_CON_CWA' AS invoice_type,
+  NULLIF(
+    TRIM(CONCAT_WS(' ', payable_claims.client_first_name, payable_claims.client_last_name)),
+    ''
+  ) AS client_name,
+  payable_claims.ufn AS case_reference,
+  payment_requests.submitted_at::date AS date_requested,
+  payable_claims.counsel_office_code AS office_code,
+  COALESCE(
+    payment_requests.allowed_total,
+    COALESCE(payment_requests.allowed_net_assigned_counsel_cost, 0) +
+      COALESCE(payment_requests.allowed_assigned_counsel_vat, 0)
+  ) AS invoice_amount_inc_vat,
+  CASE
+    WHEN COALESCE(payment_requests.allowed_assigned_counsel_vat, payment_requests.claimed_assigned_counsel_vat, 0) = 0 THEN 0
+    ELSE 20
+  END AS tax_amount_percentage,
+  'Profit costs' AS fee_type,
+  payable_claims.counsel_firm_name AS provider_reference,
+  payment_requests.request_type AS request_type,
+  payment_requests.claimed_net_assigned_counsel_cost AS claimed_net_assigned_counsel_cost,
+  payment_requests.claimed_assigned_counsel_vat AS claimed_assigned_counsel_vat,
+  payment_requests.claimed_total AS claimed_total,
+  payment_requests.allowed_net_assigned_counsel_cost AS allowed_net_assigned_counsel_cost,
+  payment_requests.allowed_assigned_counsel_vat AS allowed_assigned_counsel_vat,
+  payment_requests.allowed_total AS allowed_total,
+  payment_requests.date_claim_assessed AS date_claim_assessed,
+  payment_requests.submitted_at AS submitted_at
+FROM
+  payment_requests
+  INNER JOIN payable_claims ON payment_requests.payable_claim_id = payable_claims.id
+WHERE
+  payment_requests.request_type IN (
+    'assigned_counsel',
+    'assigned_counsel_appeal',
+    'assigned_counsel_amendment'
+  )

--- a/spec/postgres_views/assigned_counsel_payments_spec.rb
+++ b/spec/postgres_views/assigned_counsel_payments_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Assigned counsel payments" do
       "invoice_type" => "CL_CON_CWA",
       "client_name" => "Ada Lovelace",
       "case_reference" => "120423/001",
-      "date_requested" => Date.new(2026, 1, 20),
+      "date_requested" => Date.new(2026, 1, 19),
       "office_code" => "1C234D",
       "invoice_amount_inc_vat" => 540,
       "tax_amount_percentage" => 20,

--- a/spec/postgres_views/assigned_counsel_payments_spec.rb
+++ b/spec/postgres_views/assigned_counsel_payments_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Assigned counsel payments" do
+  let(:klass) do
+    Class.new(ApplicationRecord) do
+      self.table_name = :assigned_counsel_payments
+    end
+  end
+
+  it "projects CRM8 payment request fields needed by the finance dashboard" do
+    claim = create(
+      :assigned_counsel_claim,
+      client_first_name: "Ada",
+      client_last_name: "Lovelace",
+      counsel_firm_name: "Counsel Chambers",
+      counsel_office_code: "1C234D",
+      ufn: "120423/001",
+    )
+
+    travel_to(Time.zone.local(2026, 1, 20, 10, 30)) do
+      create(
+        :payment_request,
+        :assigned_counsel,
+        payable_claim: claim,
+        claimed_net_assigned_counsel_cost: 500,
+        claimed_assigned_counsel_vat: 100,
+        claimed_total: 600,
+        allowed_net_assigned_counsel_cost: 450,
+        allowed_assigned_counsel_vat: 90,
+        allowed_total: 540,
+        date_claim_assessed: Date.new(2026, 1, 19),
+      )
+    end
+
+    expect(klass.take.attributes).to include(
+      "description" => "CRM8",
+      "invoice_type" => "CL_CON_CWA",
+      "client_name" => "Ada Lovelace",
+      "case_reference" => "120423/001",
+      "date_requested" => Date.new(2026, 1, 20),
+      "office_code" => "1C234D",
+      "invoice_amount_inc_vat" => 540,
+      "tax_amount_percentage" => 20,
+      "fee_type" => "Profit costs",
+      "provider_reference" => "Counsel Chambers",
+      "payment_type" => "AC",
+      "claimed_net_assigned_counsel_cost" => 500,
+      "claimed_assigned_counsel_vat" => 100,
+      "allowed_net_assigned_counsel_cost" => 450,
+      "allowed_assigned_counsel_vat" => 90,
+    )
+  end
+
+  it "maps assigned counsel variants and excludes non CRM8 payment requests" do
+    create(:payment_request, :non_standard_magistrate)
+    create(:payment_request, :assigned_counsel)
+    create(:payment_request, :assigned_counsel_appeal)
+    create(:payment_request, :assigned_counsel_amendment)
+
+    expect(klass.pluck(:payment_type)).to contain_exactly(
+      "AC",
+      "AC Appeal",
+      "AC Amendment",
+    )
+  end
+end

--- a/spec/services/payment_requests/create_payment_request_service_spec.rb
+++ b/spec/services/payment_requests/create_payment_request_service_spec.rb
@@ -138,7 +138,20 @@ RSpec.describe PaymentRequests::CreatePaymentRequestService, type: :service do
     end
 
     context "when no submission exists for the linked reference" do
-      let(:params) { super().merge(linked_laa_reference:, id: SecureRandom.uuid) }
+      let(:params) { super().merge(linked_laa_reference:, submission_id: SecureRandom.uuid) }
+
+      it "leaves submission_id as nil" do
+        result = service.call
+        expect(result[:claim].reload.submission_id).to be_nil
+      end
+    end
+
+    context "when a different submission exists for the linked reference" do
+      let(:params) { super().merge(linked_laa_reference:, submission_id: SecureRandom.uuid) }
+
+      before do
+        create(:submission, :with_nsm_version, laa_reference: linked_laa_reference)
+      end
 
       it "leaves submission_id as nil" do
         result = service.call


### PR DESCRIPTION
## Description of change

[CRM457-2957](https://dsdmoj.atlassian.net/browse/CRM457-2957)

Adds an `assigned_counsel_payments` Scenic view for CRM8 assigned counsel payment requests so the data can be exposed through Metabase for Finance.

## Notes for reviewer

- Includes AC, AC Appeal, and AC Amendment payment request types.
- Excludes non-CRM8 payment request types from this view.
- Maps the static Finance fields from the Miro/CSV review:
  - `description`: `CRM8`
  - `invoice_type`: `CL_CON_CWA`
  - `fee_type`: `Profit costs`
- Maps `office_code` to the assigned counsel account number.
- Maps `provider_reference` to the assigned counsel name.
- Uses `date_claim_assessed` as `date_requested`, following the CRM457-3000 field rename.
- Keeps the additional claimed and allowed amount fields available in the view so Finance can confirm what they want shown in Metabase.
- A V2 sample CSV has been shared in the JIRA ticket [here](https://dsdmoj.atlassian.net/browse/CRM457-2957?focusedCommentId=795210) for product/Finance review. It shows the expected output shape from this view, including `date_requested` coming from `date_claim_assessed` and the assigned counsel account/name mappings.

## How to manually test the feature

- Run the Store test database setup.
- Query `assigned_counsel_payments` after creating assigned counsel payment request test data.
- Confirm `date_requested` comes from `date_claim_assessed`, not `submitted_at`.
- Confirm only assigned counsel request types are returned.

## Testing

- `RAILS_ENV=test asdf exec bundle exec flatware fan rake db:test:prepare`
- `asdf exec bundle exec flatware rspec`
- `asdf exec bundle exec rubocop`


[CRM457-2957]: https://dsdmoj.atlassian.net/browse/CRM457-2957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ