### PR TITLE
CRM457-3054: Make Views More Efficient: Active Providers

### DIFF
--- a/db/migrate/20260616162000_update_active_providers_to_version_2.rb
+++ b/db/migrate/20260616162000_update_active_providers_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateActiveProvidersToVersion2 < ActiveRecord::Migration[8.1]
+  def change
+    update_view :active_providers, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,17 +151,41 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
                JOIN application ON ((application_version.application_id = application.id)))
             WHERE (application_version.version = 1)
             GROUP BY application.application_type, (application_version.application -> 'office_code'::text), (date_trunc('week'::text, application_version.created_at))
+          ), weekly_submissions AS (
+           SELECT submissions.application_type,
+              submissions.submitted_start,
+              count(DISTINCT submissions.office_code) AS office_codes_submitting_during_the_period,
+              jsonb_agg(DISTINCT submissions.office_code) AS office_codes_during_the_period
+             FROM submissions
+            GROUP BY submissions.application_type, submissions.submitted_start
+          ), first_submission_weeks AS (
+           SELECT submissions.application_type,
+              submissions.office_code,
+              min(submissions.submitted_start) AS submitted_start
+             FROM submissions
+            WHERE (submissions.office_code IS NOT NULL)
+            GROUP BY submissions.application_type, submissions.office_code
+          ), provider_growth_by_week AS (
+           SELECT first_submission_weeks.application_type,
+              first_submission_weeks.submitted_start,
+              count(*) AS new_office_codes
+             FROM first_submission_weeks
+            GROUP BY first_submission_weeks.application_type, first_submission_weeks.submitted_start
+          ), cumulative_counts AS (
+           SELECT weekly_submissions_1.application_type,
+              weekly_submissions_1.submitted_start,
+              sum(COALESCE(provider_growth_by_week.new_office_codes, (0)::bigint)) OVER (PARTITION BY weekly_submissions_1.application_type ORDER BY weekly_submissions_1.submitted_start ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_office_codes_submitters
+             FROM (weekly_submissions weekly_submissions_1
+               LEFT JOIN provider_growth_by_week ON (((provider_growth_by_week.application_type = weekly_submissions_1.application_type) AND (provider_growth_by_week.submitted_start = weekly_submissions_1.submitted_start))))
           )
-   SELECT application_type,
-      submitted_start,
-      count(DISTINCT office_code) AS office_codes_submitting_during_the_period,
-      ( SELECT count(DISTINCT subs.office_code) AS count
-             FROM submissions subs
-            WHERE ((submissions.submitted_start >= subs.submitted_start) AND (submissions.application_type = subs.application_type))) AS total_office_codes_submitters,
-      jsonb_agg(DISTINCT office_code) AS office_codes_during_the_period
-     FROM submissions
-    GROUP BY application_type, submitted_start
-    ORDER BY application_type, submitted_start;
+   SELECT weekly_submissions.application_type AS application_type,
+      weekly_submissions.submitted_start AS submitted_start,
+      weekly_submissions.office_codes_submitting_during_the_period AS office_codes_submitting_during_the_period,
+      cumulative_counts.total_office_codes_submitters AS total_office_codes_submitters,
+      weekly_submissions.office_codes_during_the_period AS office_codes_during_the_period
+     FROM (weekly_submissions
+       JOIN cumulative_counts ON (((cumulative_counts.application_type = weekly_submissions.application_type) AND (cumulative_counts.submitted_start = weekly_submissions.submitted_start))))
+    ORDER BY weekly_submissions.application_type, weekly_submissions.submitted_start;
   SQL
   create_view "additional_fee_uptakes", sql_definition: <<-SQL
       WITH dates AS (

--- a/db/views/active_providers_v02.sql
+++ b/db/views/active_providers_v02.sql
@@ -1,0 +1,66 @@
+WITH submissions AS (
+  SELECT
+    application.application_type,
+    application_version.application -> 'office_code' AS office_code,
+    date_trunc('week', application_version.created_at) AS submitted_start
+  FROM application_version
+  JOIN application ON application_version.application_id = application.id
+  WHERE application_version.version = 1
+  GROUP BY 1, 2, 3
+),
+
+weekly_submissions AS (
+  SELECT
+    application_type,
+    submitted_start,
+    count(DISTINCT office_code) AS office_codes_submitting_during_the_period,
+    jsonb_agg(DISTINCT office_code) AS office_codes_during_the_period
+  FROM submissions
+  GROUP BY application_type, submitted_start
+),
+
+first_submission_weeks AS (
+  SELECT
+    application_type,
+    office_code,
+    min(submitted_start) AS submitted_start
+  FROM submissions
+  WHERE office_code IS NOT NULL
+  GROUP BY application_type, office_code
+),
+
+provider_growth_by_week AS (
+  SELECT
+    application_type,
+    submitted_start,
+    count(*) AS new_office_codes
+  FROM first_submission_weeks
+  GROUP BY application_type, submitted_start
+),
+
+cumulative_counts AS (
+  SELECT
+    weekly_submissions.application_type,
+    weekly_submissions.submitted_start,
+    sum(COALESCE(provider_growth_by_week.new_office_codes, 0)) OVER (
+      PARTITION BY weekly_submissions.application_type
+      ORDER BY weekly_submissions.submitted_start
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS total_office_codes_submitters
+  FROM weekly_submissions
+  LEFT JOIN provider_growth_by_week
+    ON provider_growth_by_week.application_type = weekly_submissions.application_type
+    AND provider_growth_by_week.submitted_start = weekly_submissions.submitted_start
+)
+
+SELECT
+  weekly_submissions.application_type AS application_type,
+  weekly_submissions.submitted_start AS submitted_start,
+  weekly_submissions.office_codes_submitting_during_the_period AS office_codes_submitting_during_the_period,
+  cumulative_counts.total_office_codes_submitters AS total_office_codes_submitters,
+  weekly_submissions.office_codes_during_the_period AS office_codes_during_the_period
+FROM weekly_submissions
+JOIN cumulative_counts
+  ON cumulative_counts.application_type = weekly_submissions.application_type
+  AND cumulative_counts.submitted_start = weekly_submissions.submitted_start
+ORDER BY weekly_submissions.application_type, weekly_submissions.submitted_start

--- a/spec/postgres_views/active_providers_spec.rb
+++ b/spec/postgres_views/active_providers_spec.rb
@@ -2,10 +2,28 @@ require "rails_helper"
 
 RSpec.describe "Active Providers" do
   let(:base_date) { Date.new(2024, 6, 26) }
+  let(:view_definition) { Rails.root.join("db/views/active_providers_v02.sql").read }
   let(:klass) do
     Class.new(ApplicationRecord) do
       self.table_name = :active_providers
     end
+  end
+
+  it "calculates cumulative provider counts without a correlated submissions self-scan" do
+    expect(view_definition).not_to match(/from\s+submissions\s+as\s+subs/i)
+    expect(view_definition).not_to match(/select\s+count\s*\(\s*distinct\s*\(\s*subs\.office_code\s*\)\s*\)/i)
+  end
+
+  it "keeps the Metabase dashboard field names" do
+    expected_fields = %w[
+      application_type
+      submitted_start
+      office_codes_submitting_during_the_period
+      total_office_codes_submitters
+      office_codes_during_the_period
+    ]
+
+    expect(klass.column_names).to eq(expected_fields)
   end
 
   it "correctly calculates the total provider counts" do


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3054)

Optimises the `active_providers` Scenic view used by Metabase reporting. The previous view calculated cumulative provider totals with a correlated self-scan over weekly submissions. The new view computes weekly submissions, first-seen provider weeks, weekly provider growth, and then uses a windowed cumulative sum.

## Notes for reviewer

Local benchmark used temporary tables with `300,000` application/version rows, `12,000` office codes, and `104` weeks, with both application types distributed across weeks. v1 and v2 produced matching aggregate summaries.

| Query shape | v1 | v2 | Improvement |
| --- | ---: | ---: | ---: |
| Full `active_providers` | 22123.505ms | 716.4ms | 96.8% |
| `crm4` since `2025-01-01` | 7999.323ms | 902.468ms | 88.7% |

The full query temp read blocks dropped from `171131` to `5531` locally.

## How to verify (post deploy)

For operational verification, review the Team Metrics Metabase dashboard with the usual filters while monitoring database I/O. The production risk is concurrent dashboard usage, so controlled UAT or production-style checks are more meaningful than only local correctness tests.
