### PR TITLE
CRM457-3053: Make submission creation times efficient

### DIFF
--- a/db/migrate/20260616120000_update_submission_creation_times_to_version_4.rb
+++ b/db/migrate/20260616120000_update_submission_creation_times_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateSubmissionCreationTimesToVersion4 < ActiveRecord::Migration[8.1]
+  def change
+    update_view :submission_creation_times, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -394,33 +394,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
     GROUP BY COALESCE((app_ver.application ->> 'service_type'::text), 'not_found'::text), (date_trunc('DAY'::text, app_ver.created_at));
   SQL
   create_view "submission_creation_times", sql_definition: <<-SQL
-      WITH base AS (
-           SELECT DISTINCT app_ver.application_id,
-              application.application_type,
-              ((app_ver.application ->> 'created_at'::text))::timestamp without time zone AS draft_created_date,
-              (app_ver.application ->> 'office_code'::text) AS office_code,
-              application_submissions.submission_date,
-                  CASE
-                      WHEN (((app_ver.application ->> 'import_date'::text))::timestamp without time zone IS NOT NULL) THEN true
-                      ELSE false
-                  END AS claim_imported
-             FROM ((application_version app_ver
-               JOIN ( SELECT application_version.application_id,
-                      min(application_version.created_at) AS submission_date
-                     FROM application_version
-                    WHERE ((application_version.application ->> 'status'::text) = 'submitted'::text)
-                    GROUP BY application_version.application_id) application_submissions ON ((app_ver.application_id = application_submissions.application_id)))
-               JOIN application ON ((app_ver.application_id = application.id)))
-            WHERE ((app_ver.application ->> 'status'::text) = 'submitted'::text)
+      WITH first_submissions AS (
+           SELECT DISTINCT ON (application_version.application_id) application_version.application_id,
+              application_version.application,
+              application_version.created_at AS submission_date
+             FROM application_version
+            WHERE ((application_version.pending IS FALSE) AND ((application_version.application ->> 'status'::text) = 'submitted'::text))
+            ORDER BY application_version.application_id, application_version.version
           )
-   SELECT application_id,
-      application_type,
-      draft_created_date,
-      office_code,
-      submission_date,
-      claim_imported,
-      (EXTRACT(epoch FROM (submission_date - draft_created_date)) / (60)::numeric) AS minutes_to_submit
-     FROM base;
+   SELECT first_submissions.application_id,
+      application.application_type,
+      ((first_submissions.application ->> 'created_at'::text))::timestamp without time zone AS draft_created_date,
+      (first_submissions.application ->> 'office_code'::text) AS office_code,
+      first_submissions.submission_date,
+      (NULLIF((first_submissions.application ->> 'import_date'::text), ''::text) IS NOT NULL) AS claim_imported,
+      (EXTRACT(epoch FROM (first_submissions.submission_date - ((first_submissions.application ->> 'created_at'::text))::timestamp without time zone)) / (60)::numeric) AS minutes_to_submit
+     FROM (first_submissions
+       JOIN application ON ((first_submissions.application_id = application.id)));
   SQL
   create_view "submissions_by_date", sql_definition: <<-SQL
       SELECT (av.created_at)::date AS event_on,

--- a/db/views/submission_creation_times_v04.sql
+++ b/db/views/submission_creation_times_v04.sql
@@ -1,0 +1,25 @@
+WITH first_submissions AS (
+  SELECT DISTINCT ON (application_id)
+    application_id,
+    application,
+    created_at AS submission_date
+  FROM application_version
+  WHERE pending IS FALSE
+    AND (application ->> 'status')::text = 'submitted'
+  ORDER BY application_id, version
+)
+
+SELECT
+  first_submissions.application_id,
+  application.application_type,
+  (first_submissions.application ->> 'created_at')::timestamp AS draft_created_date,
+  (first_submissions.application ->> 'office_code')::text AS office_code,
+  first_submissions.submission_date AS submission_date,
+  NULLIF(first_submissions.application ->> 'import_date', '') IS NOT NULL AS claim_imported,
+  EXTRACT(
+    EPOCH FROM (
+      first_submissions.submission_date - (first_submissions.application ->> 'created_at')::timestamp
+    )
+  ) / 60 AS minutes_to_submit
+FROM first_submissions
+INNER JOIN application ON first_submissions.application_id = application.id

--- a/spec/postgres_views/submission_creation_times_spec.rb
+++ b/spec/postgres_views/submission_creation_times_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "submission creation times" do
+  let(:base_time) { Time.zone.local(2024, 6, 26, 12) }
+  let(:view_definition_path) { Rails.root.join("db/views/submission_creation_times_v04.sql") }
+  let(:klass) do
+    Class.new(ApplicationRecord) do
+      self.table_name = :submission_creation_times
+    end
+  end
+
+  it "uses a single non-pending first-submitted-version query shape" do
+    expect(view_definition_path).to exist
+
+    view_definition = view_definition_path.read
+
+    expect(view_definition).to include("pending IS FALSE")
+    expect(view_definition).to include("DISTINCT ON (application_id)")
+    expect(view_definition).to include("ORDER BY application_id, version")
+    expect(view_definition).not_to match(/GROUP BY\s+application_id/i)
+  end
+
+  it "records one submission creation row from the earliest submitted version" do
+    submission = travel_to(base_time) { create(:submission, :with_pa_version, account_number: "1A123B") }
+
+    travel_to(base_time + 20.minutes) do
+      create(:submission_version, :with_pa_application, submission:, version: 2, status: "submitted", account_number: "1A123B")
+    end
+
+    expect(klass.all.map(&:attributes)).to eq([
+      { "application_id" => submission.id,
+        "application_type" => "crm4",
+        "draft_created_date" => Time.zone.local(2024, 6, 26, 11, 50),
+        "office_code" => "1A123B",
+        "submission_date" => Time.zone.local(2024, 6, 26, 12),
+        "claim_imported" => false,
+        "minutes_to_submit" => 10.0 },
+    ])
+  end
+
+  it "ignores pending submitted versions" do
+    submission = travel_to(base_time) { create(:submission, :with_pa_version, account_number: "1A123B") }
+
+    travel_to(base_time + 20.minutes) do
+      create(:submission_version, :with_pa_application,
+             submission:,
+             version: 2,
+             status: "submitted",
+             pending: true,
+             account_number: "1A123B")
+    end
+
+    expect(klass.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Description of change

[CRM457-3053](https://dsdmoj.atlassian.net/browse/CRM457-3053)

Optimises the `submission_creation_times` Scenic view by selecting the first non-pending submitted version per application using `DISTINCT ON (application_id)` ordered by `application_id, version`. This removes the grouped subquery and wider distinct pass from the previous view.

## Notes for reviewer

- Adds `submission_creation_times_v04.sql` and a Scenic migration.
- Filters pending versions before selecting the first submitted version.
- Adds postgres view specs for the query shape and pending-version behaviour.
- Corrects an existing payment request service spec setup from `id` to `submission_id` so the linked-submission missing branch is covered.

## Benchmark

Local PostgreSQL benchmark using a Metabase-style grouped query with date filtering:

- Seed: 20,000 applications / 42,000 versions
- v03: 51.553 ms, 1,038,772 shared hit blocks
- v04: 31.251 ms, 309,888 shared hit blocks
- Result: 39.4% execution-time improvement

## Testing

- `RAILS_ENV=test bundle exec flatware fan rake db:test:prepare`
- `bundle exec flatware rspec`
- `bundle exec rubocop`

[CRM457-3053]: https://dsdmoj.atlassian.net/browse/CRM457-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ