### PR TITLE
CRM457-3056: Remove Indexes that didn't Improve submission_by_services view

### DIFF
--- a/db/migrate/20260617095153_remove_indexes_for_submission_by_service.rb
+++ b/db/migrate/20260617095153_remove_indexes_for_submission_by_service.rb
@@ -1,10 +1,44 @@
 class RemoveIndexesForSubmissionByService < ActiveRecord::Migration[8.1]
-  def change
-    %w[
+  disable_ddl_transaction! #allows concurrently
+
+  def up
+    index_names = %w[
       idx_application_version_service_type_pending
       idx_application_version_pending
-    ].each do |index_name|
-      remove_index :application_version, name: index_name, if_exists: true  
+    ]
+
+    index_names.each do |index_name|
+      execute <<~SQL
+        DROP INDEX CONCURRENTLY IF EXISTS #{index_name};
+      SQL
     end
+  end
+
+  def down
+    unless index_exists_by_name("idx_application_version_service_type_pending")
+      execute <<~SQL
+        CREATE INDEX CONCURRENTLY idx_application_version_service_type_pending ON 
+        application_version (
+          application_id,
+          (application ->> 'service_type'),
+          DATE_TRUNC('DAY', created_at)
+        ) WHERE pending IS FALSE;
+      SQL
+    end
+
+    unless index_exists_by_name("idx_application_version_pending")
+      execute <<~SQL
+        CREATE INDEX CONCURRENTLY idx_application_version_pending ON application_version (application_id)
+        WHERE version = 1 AND pending IS FALSE;
+      SQL
+    end
+  end
+
+
+  private
+
+  def index_exists_by_name(index_name)
+    ActiveRecord::Base.connection.indexes(:application_version)
+      .any? { |idx| idx.name == index_name }
   end
 end

--- a/db/migrate/20260617095153_remove_indexes_for_submission_by_service.rb
+++ b/db/migrate/20260617095153_remove_indexes_for_submission_by_service.rb
@@ -1,0 +1,10 @@
+class RemoveIndexesForSubmissionByService < ActiveRecord::Migration[8.1]
+  def change
+    %w[
+      idx_application_version_service_type_pending
+      idx_application_version_pending
+    ].each do |index_name|
+      remove_index :application_version, name: index_name, if_exists: true  
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_124418) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_095153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -49,9 +49,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_124418) do
     t.index "(((application -> 'firm_office'::text) ->> 'account_number'::text))", name: "idx_application_version_on_account_number"
     t.index "((application ->> 'laa_reference'::text))", name: "idx_application_version_on_laa_reference"
     t.index "((application ->> 'status'::text)), ((created_at)::date), application_id", name: "idx_application_version_by_date_on_date_status", where: "(pending IS FALSE)"
-    t.index "application_id, ((application ->> 'service_type'::text)), date_trunc('DAY'::text, created_at)", name: "idx_application_version_service_type_pending", where: "(pending IS FALSE)"
     t.index ["application_id", "version"], name: "idx_application_versions_app_id_version"
-    t.index ["application_id"], name: "idx_application_version_pending", where: "((version = 1) AND (pending IS FALSE))"
     t.index ["search_fields"], name: "index_application_version_on_search_fields", using: :gin
   end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3056)

## Notes for reviewer
[We concluded that the submission_by_services view doesn't have it's performance improved by the indexes](https://mojdt.slack.com/archives/C05212WRK5J/p1781689506226899?thread_ts=1781689477.850249&cid=C05212WRK5J): 

- idx_application_version_service_type_pending
- idx_application_version_pending

This PR removes those indexes so that we don't have an impact on CREATE/UPDATE operations for no good reason

Note: because `remove_index` cannot be reversible if the `column` param is not present, can't do this because the indexes cannot be applied with just column so had to hand write up/down migration methods instead of using `change`