### PR TITLE
CRM457-3052 optimise sql used by metabase submission times view

### DIFF
--- a/db/migrate/20260612160000_add_index_to_application_version_on_application_id_and_created_at.rb
+++ b/db/migrate/20260612160000_add_index_to_application_version_on_application_id_and_created_at.rb
@@ -1,0 +1,24 @@
+class AddIndexToApplicationVersionOnApplicationIdAndCreatedAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "idx_app_ver_final_status_first_decision"
+  INDEX_WHERE = "(application ->> 'status') IN ('rejected', 'part_grant', 'granted')"
+
+  def up
+    return if index_exists?(:application_version, name: INDEX_NAME)
+
+    add_index :application_version,
+              %i[application_id created_at],
+              name: INDEX_NAME,
+              where: INDEX_WHERE,
+              algorithm: :concurrently
+  end
+
+  def down
+    return unless index_exists?(:application_version, name: INDEX_NAME)
+
+    remove_index :application_version,
+                 name: INDEX_NAME,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_111231) do
     t.index "(((application -> 'firm_office'::text) ->> 'account_number'::text))", name: "idx_application_version_on_account_number"
     t.index "((application ->> 'laa_reference'::text))", name: "idx_application_version_on_laa_reference"
     t.index "((application ->> 'status'::text)), ((created_at)::date), application_id", name: "idx_application_version_by_date_on_date_status", where: "(pending IS FALSE)"
+    t.index ["application_id", "created_at"], name: "idx_app_ver_final_status_first_decision", where: "((application ->> 'status'::text) = ANY (ARRAY['rejected'::text, 'part_grant'::text, 'granted'::text]))"
     t.index ["application_id", "version"], name: "idx_application_versions_app_id_version"
     t.index ["search_fields"], name: "index_application_version_on_search_fields", using: :gin
   end


### PR DESCRIPTION
## Description of change

optimise sql used by metabase submission times view

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3052)

## Notes for reviewer

```
 SELECT DISTINCT ON (application_id) application_id, application, created_at
 FROM application_version
 WHERE (application ->> 'status') IN ('rejected', 'part_grant', 'granted')
 ORDER BY application_id, created_at;
```

## Screenshots of changes (if applicable)

### Before changes:
Planning Time: 0.066 ms
Execution Time: 258.868 ms

### After changes:
Planning Time: 0.157 ms
Execution Time: 0.113 ms

## How to manually test the feature
