### PR TITLE
CRM457-3055: Dev: Make Views More Efficient: Autogrant Events

### DIFF
--- a/db/migrate/20260624094443_add_autogrant_events_filter_index.rb
+++ b/db/migrate/20260624094443_add_autogrant_events_filter_index.rb
@@ -1,0 +1,27 @@
+class AddAutograntEventsFilterIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "idx_application_auto_grant_current_version".freeze
+
+  def up
+    return if index_exists?(:application, name: INDEX_NAME)
+
+    add_index(
+      :application,
+      %i[id current_version],
+      name: INDEX_NAME,
+      where: "state = 'auto_grant'",
+      algorithm: :concurrently,
+    )
+  end
+
+  def down
+    return unless index_exists?(:application, name: INDEX_NAME)
+
+    remove_index(
+      :application,
+      name: INDEX_NAME,
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/migrate/20260624094444_update_autogrant_events_to_version_4.rb
+++ b/db/migrate/20260624094444_update_autogrant_events_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateAutograntEventsToVersion4 < ActiveRecord::Migration[8.1]
+  def change
+    update_view :autogrant_events, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_151830) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_094444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_151830) do
     t.index ["application_type", "last_updated_at"], name: "idx_application_on_type_last_updated_at"
     t.index ["application_type"], name: "idx_application_type"
     t.index ["application_type"], name: "idx_application_version_type"
+    t.index ["id", "current_version"], name: "idx_application_auto_grant_current_version", where: "(state = 'auto_grant'::text)"
   end
 
   add_check_constraint "application", "created_at IS NOT NULL", name: "application_created_at_null", validate: false
@@ -265,9 +266,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_151830) do
       av.version AS submission_version,
       (av.created_at)::date AS event_on,
       (av.application ->> 'service_type'::text) AS service_key,
-      COALESCE((av.application ->> 'custom_service_name'::text), (COALESCE(t.translation, ((av.application ->> 'service_type'::text))::character varying))::text) AS service
-     FROM ((application_version av
-       JOIN application a ON (((a.id = av.application_id) AND (a.current_version = av.version))))
+      COALESCE((av.application ->> 'custom_service_name'::text), (t.translation)::text, (av.application ->> 'service_type'::text)) AS service
+     FROM ((application a
+       JOIN application_version av ON (((av.application_id = a.id) AND (av.version = a.current_version))))
        LEFT JOIN translations t ON ((((t.key)::text = (av.application ->> 'service_type'::text)) AND ((t.translation_type)::text = 'service'::text))))
     WHERE (a.state = 'auto_grant'::text);
   SQL

--- a/db/views/autogrant_events_v04.sql
+++ b/db/views/autogrant_events_v04.sql
@@ -1,0 +1,18 @@
+SELECT
+  a.id,
+  av.version AS submission_version,
+  av.created_at::date AS event_on,
+  av.application ->> 'service_type' AS service_key,
+  COALESCE(
+    av.application ->> 'custom_service_name',
+    t.translation,
+    av.application ->> 'service_type'
+  ) AS service
+FROM application a
+JOIN application_version av
+  ON av.application_id = a.id
+  AND av.version = a.current_version
+LEFT JOIN translations t
+  ON t.key = av.application ->> 'service_type'
+  AND t.translation_type = 'service'
+WHERE a.state = 'auto_grant'

--- a/spec/postgres_views/autogrant_events_spec.rb
+++ b/spec/postgres_views/autogrant_events_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "autogrant_events" do
+  let(:view_definition) { Rails.root.join("db/views/autogrant_events_v04.sql").read }
   let(:klass) do
     Class.new(ApplicationRecord) do
       self.table_name = :autogrant_events
@@ -11,6 +12,28 @@ RSpec.describe "autogrant_events" do
 
   before do
     Translation.find_or_create_by(key: "ae_consultant", translation: "A&E consultant", translation_type: "service")
+  end
+
+  it "keeps the Metabase dashboard field names" do
+    expect(klass.column_names).to eq(%w[id submission_version event_on service_key service])
+  end
+
+  it "filters to autogrants without using the legacy event views" do
+    expect(view_definition).to match(/FROM\s+application\s+a/i)
+    expect(view_definition).to include("a.state = 'auto_grant'")
+    expect(view_definition).not_to include("application_type")
+    expect(view_definition).not_to match(/\ball_events\b/i)
+  end
+
+  it "has a partial index supporting the autogrant application filter" do
+    index = ActiveRecord::Base.connection.indexes(:application).find do |idx|
+      idx.name == "idx_application_auto_grant_current_version"
+    end
+
+    expect(index).to be_present
+    expect(index.columns).to eq(%w[id current_version])
+    expect(index.where).to match(/state.*auto_grant/)
+    expect(index.where).not_to match(/application_type/)
   end
 
   it "returns no records when no autogranted applications exist" do
@@ -44,6 +67,18 @@ RSpec.describe "autogrant_events" do
 
     expect(klass.all.map(&:attributes)).to eq([
       { "id" => submission.id, "submission_version" => 1, "event_on" => today.to_date, "service_key" => "custom", "service" => "Test" },
+    ])
+  end
+
+  it "keeps non-CRM4 autogranted applications in the output" do
+    submission = create(
+      :submission,
+      :with_nsm_version,
+      state: :auto_grant,
+    )
+
+    expect(klass.all.map(&:attributes)).to eq([
+      { "id" => submission.id, "submission_version" => 1, "event_on" => today.to_date, "service_key" => nil, "service" => nil },
     ])
   end
 end


### PR DESCRIPTION
## Description of change

[CRM457-3055](https://dsdmoj.atlassian.net/browse/CRM457-3055)

Optimises the `autogrant_events` Metabase view while preserving the existing view interface and output semantics.

The view still exposes the same columns and still filters only on `state = 'auto_grant'`. No application type predicate or output alias change is introduced.

Adds a partial concurrent index for autogranted applications so the view can start from the filtered `application` rows and then fetch the current version.

## Notes for reviewer

No functional output changes intended:
- Columns remain `id`, `submission_version`, `event_on`, `service_key`, `service`
- No new aliases
- Non-CRM4 autogrants remain in the output
- The view no longer depends on the broader event views

Benchmark on a generated local dataset:

```text
v03_without_new_index: rows=40, planning_ms=32.094, execution_ms=1.538
v04_with_new_index: rows=40, planning_ms=0.155, execution_ms=0.158
```

The new query uses `idx_application_auto_grant_current_version`.

## How to manually test the feature

Run the Store migrations and query `autogrant_events`; it should return autogranted applications with the expected service fields from the current submission version.


[CRM457-3055]: https://dsdmoj.atlassian.net/browse/CRM457-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ