### PR TITLE
CRM457-2512: Log request IDs

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
   config.lograge.custom_payload do |controller|
     {
       client_role: controller.current_client_role,
+      request_id: controller.request.headers["request-id"],
     }
   end
 end

--- a/spec/initializers/lograge_spec.rb
+++ b/spec/initializers/lograge_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Lograge do
+  it "includes the request id for app log correlation" do
+    headers = ActionDispatch::Http::Headers.from_hash(
+      "HTTP_REQUEST_ID" => "nscc-submit-rails-request-id",
+    )
+    request = instance_double(ActionDispatch::Request, headers:)
+    controller = instance_double(
+      ApplicationController,
+      current_client_role: :provider,
+      request:,
+    )
+
+    expect(Rails.application.config.lograge.custom_payload_method.call(controller)).to eq(
+      client_role: :provider,
+      request_id: "nscc-submit-rails-request-id",
+    )
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2512)

Adds inbound `request-id` values to App Store structured Lograge payloads as `request_id`, so incoming correlation ids from Submit and Assess can be found in App Store application logs using the same field name as the caller apps.

## Notes for reviewer

- The existing `client_role` payload is unchanged.
- Missing `request-id` headers log as `nil`.
- The app log field is intentionally named `request_id` to align Submit, Assess and App Store with a single searchable correlation field.
- This is a logging/tracing change only; no UI changes.

## Testing

- Focused Lograge spec passed: `1 example, 0 failures`.
- RuboCop passed: `167 files inspected, no offenses detected`.

## How to manually test the feature

Call App Store with a `request-id` header, then check OpenSearch for the same value in App Store structured logs under `request_id`.
