### PR TITLE
CRM457-3134: Add Gitleaks CI

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,110 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    # Keep the pull-request job name stable so branch protection can require it.
+    name: "${{ github.event_name == 'pull_request' && 'Gitleaks PR' || github.event_name == 'push' && 'Gitleaks push' || 'Gitleaks manual' }}"
+    if: github.event_name != 'push' || github.event.deleted == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Gitleaks
+        env:
+          # Update the version and release checksum together.
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+
+          archive_name="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          release_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          archive="${RUNNER_TEMP}/${archive_name}"
+          install_dir="${RUNNER_TEMP}/gitleaks"
+
+          curl --fail --silent --show-error --location --retry 3 \
+            "${release_url}/${archive_name}" \
+            --output "${archive}"
+
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check --status
+          mkdir -p "${install_dir}"
+          tar -xzf "${archive}" -C "${install_dir}" gitleaks
+          "${install_dir}/gitleaks" version
+
+      - name: Determine commits to scan
+        id: commits
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # PRs provide base/head SHAs; pushes provide before/current SHAs.
+          # New branches and manual runs fall back to the default-branch merge base.
+          # Unrelated histories have no base, so their full history is scanned.
+          zero_sha="0000000000000000000000000000000000000000"
+          head_sha="${PR_HEAD_SHA:-${EVENT_HEAD_SHA}}"
+          base_sha="${PR_BASE_SHA:-${BEFORE_SHA}}"
+
+          git cat-file -e "${head_sha}^{commit}"
+
+          if [[ -z "${base_sha}" ]] ||
+            [[ "${base_sha}" == "${zero_sha}" ]] ||
+            ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            base_sha="$(
+              git merge-base "origin/${DEFAULT_BRANCH}" "${head_sha}" 2>/dev/null || true
+            )"
+          fi
+
+          if [[ -z "${base_sha}" ]]; then
+            scan_range="${head_sha}"
+          elif [[ "${base_sha}" != "${head_sha}" ]]; then
+            scan_range="${base_sha}..${head_sha}"
+          elif git rev-parse --verify --quiet "${head_sha}^" >/dev/null; then
+            scan_range="${head_sha}^..${head_sha}"
+          else
+            scan_range="${head_sha}"
+          fi
+
+          git rev-list --max-count=1 "${scan_range}" >/dev/null
+          echo "Scanning introduced commits: ${scan_range}"
+          echo "range=${scan_range}" >> "${GITHUB_OUTPUT}"
+
+      - name: Scan introduced commits
+        env:
+          SCAN_RANGE: ${{ steps.commits.outputs.range }}
+        run: |
+          set -euo pipefail
+
+          if ! "${RUNNER_TEMP}/gitleaks/gitleaks" git \
+            --log-opts="${SCAN_RANGE}" \
+            --redact \
+            --no-banner \
+            --verbose \
+            .; then
+            error_message="Gitleaks did not pass. Review the finding or error above. "
+            error_message+="If a secret was detected, remove it from every commit in this branch, "
+            error_message+="rotate any real credential, and push rewritten history "
+            error_message+="before requesting review."
+            echo "::error::${error_message}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

[CRM457-3134](https://dsdmoj.atlassian.net/browse/CRM457-3134)

Adds a build-blocking Gitleaks workflow to App Store, following the workflow proven and merged in [Submit #1877](https://github.com/ministryofjustice/laa-submit-crime-forms/pull/1877).

The workflow runs on pull requests, pushes to every branch, and manual dispatches. It scans the commits introduced by the event, redacts detected values, and fails with remediation guidance when Gitleaks does not pass.

## Implementation notes

- Matches the Gitleaks workflow merged into Submit.
- Downloads Gitleaks 8.30.1 and verifies the release archive checksum before execution.
- Uses a pinned checkout action and read-only repository permissions.
- Handles pull requests, linear pushes, new branches, diverged force-pushes, and manual runs without scanning unrelated history.
- Reports separate `Gitleaks PR`, `Gitleaks push`, and `Gitleaks manual` check names so branch protection can require the PR check without conflating event types.
- Avoids a licensed action, SARIF, and GitHub Advanced Security dependencies.

A push to a branch with an open pull request intentionally produces both a push scan and a pull-request scan. The push scan catches commits immediately on any repository branch; the PR scan validates the complete change relative to its target branch.

## Deployment notes

No application deployment or configuration change is required. Once this workflow has produced a successful pull-request run, `Gitleaks PR` must be added to the required checks for the protected `main` branch. The push and manual checks should remain non-required.

The ticket's synthetic secret failure-and-recovery evidence will be captured separately on a non-production validation branch.


[CRM457-3134]: https://dsdmoj.atlassian.net/browse/CRM457-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ